### PR TITLE
fixed uuid4 dependency and deprecation

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,4 +1,4 @@
-const uuidv4 = require('uuid/v4');
+const { v4: uuidv4 } = require('uuid');
 const {CallDirection} = require('./utils/constants');
 const CallInfo = require('./session/call-info');
 const Requestor = require('./utils/requestor');

--- a/lib/session/call-info.js
+++ b/lib/session/call-info.js
@@ -1,6 +1,6 @@
 const {CallDirection, CallStatus} = require('../utils/constants');
 const parseUri = require('drachtio-srf').parseUri;
-const uuidv4 = require('uuid/v4');
+const { v4: uuidv4 } = require('uuid');
 
 /**
  * @classdesc Represents the common information for all calls

--- a/lib/tasks/task.js
+++ b/lib/tasks/task.js
@@ -1,5 +1,5 @@
 const Emitter = require('events');
-const uuidv4 = require('uuid/v4');
+const { v4: uuidv4 } = require('uuid');
 const debug = require('debug')('jambonz:feature-server');
 const assert = require('assert');
 const {TaskPreconditions} = require('../utils/constants');

--- a/lib/utils/place-outdial.js
+++ b/lib/utils/place-outdial.js
@@ -13,7 +13,7 @@ const registrar = new Registrar({
 });
 const deepcopy = require('deepcopy');
 const moment = require('moment');
-const uuidv4 = require('uuid/v4');
+const { v4: uuidv4 } = require('uuid');
 
 class SingleDialer extends Emitter {
   constructor({logger, sbcAddress, target, opts, application, callInfo}) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1138,6 +1138,11 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -1150,6 +1155,13 @@
         "eventemitter2": "^4.1",
         "uuid": "^3.1.0",
         "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "drachtio-mw-registration-parser": {
@@ -2253,6 +2265,12 @@
           "requires": {
             "glob": "^7.1.3"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -3904,9 +3922,9 @@
       "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "moment": "^2.29.1",
     "parse-url": "^5.0.2",
     "pino": "^6.8.0",
+    "uuid": "^8.3.2",
     "verify-aws-sns-signature": "^0.0.6",
     "xml2js": "^0.4.23"
   },


### PR DESCRIPTION
Issue when running in a container or an empty NodeJS environment.
Deep Requires No Longer Supported in UUID
Deep requires like require('uuid/v4') which have been deprecated in uuid@7.x are no longer supported.

added UUID to dependency in project instead of relying on sub modules.
updated require statements to be compatible with latest UUID module. 