### PR TITLE
Use lts version of node instead of latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:slim
+FROM node:lts-slim
 WORKDIR /opt/app/
 COPY package.json package-lock.json ./
 RUN npm ci


### PR DESCRIPTION
Currently this project is affected by one of node 18 (latest version) breaking change which impact node-ip dependence:
https://github.com/indutny/node-ip/pull/114
https://github.com/nodejs/node/issues/42787. 

For more details you could check the attached logs  from selfhosted jambonz-feature-server  
[feature-server-6878656995-p96kp.log](https://github.com/jambonz/jambonz-feature-server/files/8603845/feature-server-6878656995-p96kp.log)
