### PR TITLE
add defaults to rest call payload

### DIFF
--- a/lib/tasks/rest_dial.js
+++ b/lib/tasks/rest_dial.js
@@ -50,7 +50,22 @@ class TaskRestDial extends Task {
     try {
       const b3 = this.getTracingPropagation();
       const httpHeaders = b3 && {b3};
-      const tasks = await cs.requestor.request('session:new', this.call_hook, cs.callInfo, httpHeaders);
+      const params = {
+        ...cs.callInfo,
+          defaults: {
+            synthesizer: {
+              vendor: cs.speechSynthesisVendor,
+              language: cs.speechSynthesisLanguage,
+              voice: cs.speechSynthesisVoice
+            },
+            recognizer: {
+              vendor:  cs.speechRecognizerVendor,
+              language: cs.speechRecognizerLanguage
+            }
+          }
+        };
+      
+      const tasks = await cs.requestor.request('session:new', this.call_hook, params, httpHeaders);
       if (tasks && Array.isArray(tasks)) {
         this.logger.debug({tasks: tasks}, `TaskRestDial: replacing application with ${tasks.length} tasks`);
         cs.replaceApplication(normalizeJambones(this.logger, tasks).map((tdata) => makeTask(this.logger, tdata)));


### PR DESCRIPTION
This PR adds application default settings such as recognizer and synthesizer as payload which is sent on the session:new event upon connection to the application when placing an **outbound call**

Now the application defaults are sent on both, inbound and outbound session:new events.

This PR fixes #114 