### PR TITLE
Fix/play timeout

### DIFF
--- a/lib/session/call-session.js
+++ b/lib/session/call-session.js
@@ -114,6 +114,10 @@ class CallSession extends Emitter {
     return this.callInfo.applicationSid;
   }
 
+  get callStatus() {
+    return this.callInfo.callStatus;
+  }
+
   /**
    * SIP call-id for the call
    */

--- a/lib/tasks/play.js
+++ b/lib/tasks/play.js
@@ -1,5 +1,5 @@
 const Task = require('./task');
-const {TaskName, TaskPreconditions} = require('../utils/constants');
+const {TaskName, TaskPreconditions, CallStatus} = require('../utils/constants');
 
 class TaskPlay extends Task {
   constructor(logger, opts) {
@@ -22,6 +22,13 @@ class TaskPlay extends Task {
   async exec(cs, {ep}) {
     await super.exec(cs);
     this.ep = ep;
+    let timeout;
+    let playbackSeconds = 0;
+    let playbackMilliseconds = 0;
+    let completed = !(this.timeoutSecs > 0 || this.loop);
+    if (this.timeoutSecs > 0) {
+      timeout = setTimeout(() => { completed = true; this.kill(cs); }, this.timeoutSecs * 1000);
+    }
     try {
       while (!this.killed && (this.loop === 'forever' || this.loop--) && this.ep.connected) {
         if (cs.isInConference) {
@@ -34,14 +41,23 @@ class TaskPlay extends Task {
             await this.playToConfMember(this.ep, memberId, confName, confUuid, this.url);
           }
         } else {
-          const file = (this.timeoutSecs >= 0 || this.seekOffset >= 0) ?
-            {file: this.url, seekOffset: this.seekOffset, timeoutSecs: this.timeoutSecs} : this.url;
+          let file = this.url;
+          if (this.seekOffset >= 0) {
+            file = {file: this.url, seekOffset: this.seekOffset};
+            this.seekOffset = -1;
+          }
           const result = await ep.play(file);
-          await this.performAction(Object.assign(result, {reason: 'playCompleted'}),
-            !(this.parentTask || cs.isConfirmCallSession));
+          playbackSeconds += parseInt(result.playbackSeconds);
+          playbackMilliseconds += parseInt(result.playbackMilliseconds);
+          if (cs.callStatus === CallStatus.Completed || !this.loop || completed) {
+            if (timeout) clearTimeout(timeout);
+            await this.performAction(Object.assign(result, {reason: 'playCompleted', playbackSeconds, playbackMilliseconds}),
+              !(this.parentTask || cs.isConfirmCallSession));
+          }
         }
       }
     } catch (err) {
+      if (timeout) clearTimeout(timeout);
       this.logger.info(err, `TaskPlay:exec - error playing ${this.url}`);
     }
     this.emit('playDone');

--- a/lib/tasks/play.js
+++ b/lib/tasks/play.js
@@ -27,7 +27,14 @@ class TaskPlay extends Task {
     let playbackMilliseconds = 0;
     let completed = !(this.timeoutSecs > 0 || this.loop);
     if (this.timeoutSecs > 0) {
-      timeout = setTimeout(() => { completed = true; this.kill(cs); }, this.timeoutSecs * 1000);
+      timeout = setTimeout(async() => {
+        completed = true;
+        try {
+          await this.kill(cs);
+        } catch (err) {
+          this.logger.info(err, 'Error killing audio on timeoutSecs');
+        }
+      }, this.timeoutSecs * 1000);
     }
     try {
       while (!this.killed && (this.loop === 'forever' || this.loop--) && this.ep.connected) {
@@ -51,7 +58,8 @@ class TaskPlay extends Task {
           playbackMilliseconds += parseInt(result.playbackMilliseconds);
           if (cs.callStatus === CallStatus.Completed || !this.loop || completed) {
             if (timeout) clearTimeout(timeout);
-            await this.performAction(Object.assign(result, {reason: 'playCompleted', playbackSeconds, playbackMilliseconds}),
+            await this.performAction(
+              Object.assign(result, {reason: 'playCompleted', playbackSeconds, playbackMilliseconds}),
               !(this.parentTask || cs.isConfirmCallSession));
           }
         }

--- a/lib/tasks/play.js
+++ b/lib/tasks/play.js
@@ -56,7 +56,7 @@ class TaskPlay extends Task {
           const result = await ep.play(file);
           playbackSeconds += parseInt(result.playbackSeconds);
           playbackMilliseconds += parseInt(result.playbackMilliseconds);
-          if (cs.callStatus === CallStatus.Completed || !this.loop || completed) {
+          if (this.killed || !this.loop || completed) {
             if (timeout) clearTimeout(timeout);
             await this.performAction(
               Object.assign(result, {reason: 'playCompleted', playbackSeconds, playbackMilliseconds}),


### PR DESCRIPTION
Update timeoutSecs to work outside of FreeSwitch to allow for looping audio.

A scenario where a 15 second audio clip is set to timeout after 20 seconds and loop is > 1, the audio clip will continue to be played and the webhook called after every iteration.

playbackLastOffsetPos is still the last position in the current iteration.
playbackSeconds and playbackMilliseconds are cumulative.
seekOffset is reset after the first iteration.

I've exposed callStatus to take account of the caller hanging up, I wasn't sure if this is the best way of doing it.

The try catch within the timeout is pointless, I added it encase kill was ever to throw.