### PR TITLE
Fix/conference wait hook

### DIFF
--- a/lib/tasks/conference.js
+++ b/lib/tasks/conference.js
@@ -427,13 +427,19 @@ class Conference extends Task {
         .catch((err) => this.logger.info({err}, 'Error deafing or undeafing participant'));
     }
 
+    if (wait_hook) {
+      if (this.wait_hook)
+        delete this.wait_hook.url;
+      this.wait_hook = {url: wait_hook};
+    }
+
     if (hookOnly && this._playSession) {
       this._playSession.kill();
       this._playSession = null;
     }
-    if (wait_hook && this.conf_hold_status === 'hold') {
+    if (this.wait_hook?.url && this.conf_hold_status === 'hold') {
       const {dlg} = cs;
-      this._doWaitHookWhileOnHold(cs, dlg, wait_hook);
+      this._doWaitHookWhileOnHold(cs, dlg, this.wait_hook);
     }
     else if (this.conf_hold_status !== 'hold' && this._playSession) {
       this._playSession.kill();
@@ -444,7 +450,9 @@ class Conference extends Task {
   async _doWaitHookWhileOnHold(cs, dlg, wait_hook) {
     do {
       try {
-        const tasks = await this._playHook(cs, dlg, wait_hook);
+        let tasks = [];
+        if (wait_hook.url)
+          tasks = await this._playHook(cs, dlg, wait_hook.url);
         if (0 === tasks.length) break;
       } catch (err) {
         if (!this.killed) {

--- a/lib/tasks/conference.js
+++ b/lib/tasks/conference.js
@@ -108,6 +108,10 @@ class Conference extends Task {
   async kill(cs) {
     super.kill(cs);
     this.logger.info(`Conference:kill ${this.confName}`);
+    if (this._playSession) {
+      this._playSession.kill();
+      this._playSession = null;
+    }
     this.emitter.emit('kill');
     await this._doFinalMemberCheck(cs);
     if (this.ep && this.ep.connected) this.ep.conn.removeAllListeners('esl::event::CUSTOM::*') ;
@@ -579,6 +583,10 @@ class Conference extends Task {
    */
   _kicked(cs, dlg) {
     this.logger.info(`Conference:kicked - I was dropped from conference ${this.confName}, task is complete`);
+    if (this._playSession) {
+      this._playSession.kill();
+      this._playSession = null;
+    }
     this.replaceEndpointAndEnd(cs);
   }
 


### PR DESCRIPTION
A small issue we ran into where an old conference wait hook is called even if the wait hook has been updated, causing unexpected audio. I deref the URL when setting a new wait hook so the previous wait hook stops being called.

We also noticed when re-directing a call out of a conference, while a wait hook is in use, the audio wasn't stopping. I've added two `_playSession.kill()` on what I think are the only exit paths. I'm happy to make this a separate PR.