### PR TITLE
Fix incorrect target.auth reference in createCall

### DIFF
--- a/lib/http-routes/api/create-call.js
+++ b/lib/http-routes/api/create-call.js
@@ -104,7 +104,7 @@ router.post('/', async(req, res) => {
       proxy: `sip:${sbcAddress}`,
       localSdp: ep.local.sdp
     });
-    if (target.auth) opts.auth = this.target.auth;
+    if (target.auth) opts.auth = target.auth;
 
 
     /**


### PR DESCRIPTION
API generated calls to registered clients as the initial target fail due to no credentials. This is due to create-call.js referencing `this.target.auth` instead of `target.auth` as its a locally defined constant.

