### PR TITLE
Feature: Use callSid as Jaeger traceId

### DIFF
--- a/lib/utils/call-tracer.js
+++ b/lib/utils/call-tracer.js
@@ -1,5 +1,7 @@
 const {context, trace} = require('@opentelemetry/api');
 const {Dialog} = require('drachtio-srf');
+const {uuid} = require('uuid');
+
 class RootSpan {
   constructor(callType, req) {
     let tracer, callSid, linkedSpanId;
@@ -15,6 +17,8 @@ class RootSpan {
       callSid = req.locals.callSid;
     }
     this._span = tracer.startSpan(callType || 'incoming-call');
+    this._span._spanContext.traceId = this.getHexValue(callSid);
+
     if (req instanceof Dialog) {
       const dlg = req;
       this._span.setAttributes({
@@ -34,6 +38,11 @@ class RootSpan {
 
     this._ctx = trace.setSpan(context.active(), this._span);
     this.tracer = tracer;
+  }
+
+  getHexValue(callSid) {
+    const callSidBytes = uuid.parse(callSid);
+    return new Buffer(callSidBytes).toString('hex');
   }
 
   get context() {

--- a/lib/utils/call-tracer.js
+++ b/lib/utils/call-tracer.js
@@ -1,6 +1,5 @@
 const {context, trace} = require('@opentelemetry/api');
 const {Dialog} = require('drachtio-srf');
-const {uuid} = require('uuid');
 
 class RootSpan {
   constructor(callType, req) {
@@ -11,8 +10,7 @@ class RootSpan {
       tracer = dlg.srf.locals.otel.tracer;
       callSid = dlg.callSid;
       linkedSpanId = dlg.linkedSpanId;
-    }
-    else {
+    } else {
       tracer = req.srf.locals.otel.tracer;
       callSid = req.locals.callSid;
     }
@@ -25,8 +23,7 @@ class RootSpan {
         linkedSpanId,
         callId: dlg.sip.callId
       });
-    }
-    else {
+    } else {
       this._span.setAttributes({
         callSid,
         accountSid: req.get('X-Account-Sid'),
@@ -41,8 +38,7 @@ class RootSpan {
   }
 
   getHexValue(callSid) {
-    const callSidBytes = uuid.parse(callSid);
-    return new Buffer(callSidBytes).toString('hex');
+    return callSid.replaceAll('-', '');
   }
 
   get context() {
@@ -63,7 +59,7 @@ class RootSpan {
 
   getTracingPropagation(encoding) {
     // TODO: support encodings beyond b3 https://github.com/openzipkin/b3-propagation
-    if (this._span  && this.traceId !== '00000000000000000000000000000000') {
+    if (this._span && this.traceId !== '00000000000000000000000000000000') {
       return `${this.traceId}-${this.spanId}-1`;
     }
   }


### PR DESCRIPTION
By luck it appears the jaeger traceId needs to be a valid 16 byte hex. This is easily converted from a v4 UUID and means we can use the callSid as the traceId.

The idea is that we could then implement this for sbc-inbound, sbc-outbound and ultimately trace all the sip services without the need for complex logic.

Confirmed trace in Jaeger UI

![image](https://user-images.githubusercontent.com/23122590/230799320-6971594a-bd59-4590-a1fa-deefe2dde190.png)
