### PR TITLE
Bug/gather race condition

### DIFF
--- a/lib/session/call-session.js
+++ b/lib/session/call-session.js
@@ -529,7 +529,11 @@ class CallSession extends Emitter {
           this.logger.info({currInput, newInput},
             'CallSession:enableBotMode - restarting background gather to apply new input type');
           this.backgroundGatherTask.sticky = false;
-          this.disableBotMode();
+          await this.backgroundGatherTask.removeAllListeners();
+          await this.backgroundGatherTask.kill()
+            .catch((err) => {
+              this.logger.info({err}, 'CallSession:enableBotMode - kill gather');
+            });
         }
       }
       this.backgroundGatherTask = task;
@@ -573,8 +577,13 @@ class CallSession extends Emitter {
     if (this.backgroundGatherTask) {
       try {
         this.backgroundGatherTask.removeAllListeners();
-        this.backgroundGatherTask.kill().catch((err) => {});
-      } catch (err) {}
+        this.backgroundGatherTask.kill()
+          .catch((err) => {
+            this.logger.info({ err }, 'CallSession:disableBotMode: kill gather');
+          });
+      } catch (err) {
+        this.logger.info({ err }, 'CallSession:disableBotMode: error while remove and kill gather');
+      }
       this.backgroundGatherTask = null;
     }
   }


### PR DESCRIPTION
This PR fixes a bug  where two `gather` could be active at the same time since we did not await the kill of the first one before creating the second one.

