### PR TITLE
Fix: Addressing #333 using a redirect task

### DIFF
--- a/lib/session/call-session.js
+++ b/lib/session/call-session.js
@@ -998,30 +998,19 @@ ${credential.label ? `, label: ${credential.label}` : ''} is chosen`);
    * @param {object} [opts.call_hook] - new call_status_hook
    */
   async _lccCallHook(opts) {
-    const webhooks = [];
     let sd, tasks, childTasks;
-    const b3 = this.b3;
-    const httpHeaders = b3 && {b3};
-
     if (opts.call_hook || opts.child_call_hook) {
       if (opts.call_hook) {
-        webhooks.push(this.requestor.request('session:redirect', opts.call_hook, this.callInfo.toJSON(), httpHeaders));
+        tasks = [{verb: 'redirect', actionHook: opts.call_hook}];
       }
       if (opts.child_call_hook) {
         /* child call hook only allowed from a connected Dial state */
         const task = this.currentTask;
         sd = task.sd;
         if (task && TaskName.Dial === task.name && sd) {
-          webhooks.push(this.requestor.request(
-            'session:redirect', opts.child_call_hook, sd.callInfo.toJSON(), httpHeaders));
+          childTasks = [{verb: 'redirect', actionHook: opts.child_call_hook}];
         }
       }
-      const [tasks1, tasks2] = await Promise.all(webhooks);
-      if (opts.call_hook) {
-        tasks = tasks1;
-        if (opts.child_call_hook) childTasks = tasks2;
-      }
-      else childTasks = tasks1;
     }
     else if (opts.parent_call || opts.child_call) {
       const {parent_call, child_call} = opts;

--- a/lib/tasks/conference.js
+++ b/lib/tasks/conference.js
@@ -115,7 +115,7 @@ class Conference extends Task {
     this.emitter.emit('kill');
     await this._doFinalMemberCheck(cs);
     if (this.ep && this.ep.connected) {
-      this.ep.conn.removeAllListeners('esl::event::CUSTOM::*');
+      this.ep.conn.removeListener('esl::event::CUSTOM::*', this.onConferenceEventCb);
       this.ep.api(`conference ${this.confName} kick ${this.memberId}`)
         .catch((err) => this.logger.info({err}, 'Error kicking participant'));
     }
@@ -373,9 +373,13 @@ class Conference extends Task {
         }
       }
 
+      this.onConferenceEventCb = (evt) => {
+        this.__onConferenceEvent(cs, evt);
+      }
+
       // listen for conference events
       this.ep.filter('Conference-Unique-ID', this.confUuid);
-      this.ep.conn.on('esl::event::CUSTOM::*', this.__onConferenceEvent.bind(this, cs)) ;
+      this.ep.conn.on('esl::event::CUSTOM::*', this.onConferenceEventCb) ;
 
       // optionally play beep to conference on entry
       if (this.beep === true) {

--- a/lib/tasks/task.js
+++ b/lib/tasks/task.js
@@ -1,5 +1,6 @@
 const Emitter = require('events');
 const uuidv4 = require('uuid-random');
+const {AbortController} = require('abort-controller');
 const {TaskPreconditions} = require('../utils/constants');
 const { normalizeJambones } = require('@jambonz/verb-specifications');
 const WsRequestor = require('../utils/ws-requestor');
@@ -65,6 +66,7 @@ class Task extends Emitter {
   kill(cs) {
     if (this.cs && !this.cs.isConfirmCallSession) this.logger.debug(`${this.name} is being killed`);
     this._killInProgress = true;
+    this._abortController?.abort();
 
     /* remove reference to parent task or else entangled parent-child tasks will not be gc'ed */
     setImmediate(() => this.parentTask = null);
@@ -158,9 +160,16 @@ class Task extends Emitter {
       const span = this.startSpan(`${type} (${this.actionHook})`);
       const b3 = this.getTracingPropagation('b3', span);
       const httpHeaders = b3 && {b3};
+      if (expectResponse) this._abortController = new AbortController();
       span.setAttributes({'http.body': JSON.stringify(params)});
       try {
-        const json = await this.cs.requestor.request(type, this.actionHook, params, httpHeaders);
+        const json = await this.cs.requestor.request(
+          type,
+          this.actionHook,
+          params,
+          httpHeaders,
+          this._abortController?.signal
+        );
         span.setAttributes({'http.statusCode': 200});
         span.end();
         if (expectResponse && json && Array.isArray(json)) {
@@ -172,9 +181,9 @@ class Task extends Emitter {
           }
         }
       } catch (err) {
-        span.setAttributes({'http.statusCode': err.statusCode});
+        span.setAttributes({'http.statusCode': err.statusCode ?? 400});
         span.end();
-        throw err;
+        if (!this._killInProgress) throw err;
       }
     }
   }
@@ -184,9 +193,10 @@ class Task extends Emitter {
     const span = this.startSpan('verb:hook', {'hook.url': hook});
     const b3 = this.getTracingPropagation('b3', span);
     const httpHeaders = b3 && {b3};
+    this._abortController = new AbortController();
     span.setAttributes({'http.body': JSON.stringify(params)});
     try {
-      const json = await cs.requestor.request('verb:hook', hook, params, httpHeaders);
+      const json = await cs.requestor.request('verb:hook', hook, params, httpHeaders, this._abortController.signal);
       span.setAttributes({'http.statusCode': 200});
       span.end();
       if (json && Array.isArray(json)) {
@@ -199,9 +209,9 @@ class Task extends Emitter {
       }
       return false;
     } catch (err) {
-      span.setAttributes({'http.statusCode': err.statusCode});
+      span.setAttributes({'http.statusCode': err.statusCode ?? 400});
       span.end();
-      throw err;
+      if (!this._killInProgress) throw err;
     }
   }
 

--- a/lib/utils/http-requestor.js
+++ b/lib/utils/http-requestor.js
@@ -81,7 +81,7 @@ class HttpRequestor extends BaseRequestor {
    * @param {string} [hook.password] - if basic auth is protecting the endpoint
    * @param {object} [params] - request parameters
    */
-  async request(type, hook, params, httpHeaders = {}) {
+  async request(type, hook, params, httpHeaders = {}, abortSignal) {
     /* jambonz:error only sent over ws */
     if (type === 'jambonz:error') return;
 
@@ -146,7 +146,8 @@ class HttpRequestor extends BaseRequestor {
         headers: hdrs,
         ...('POST' === method && {body: JSON.stringify(payload)}),
         timeout: HTTP_TIMEOUT,
-        followRedirects: false
+        followRedirects: false,
+        signal: abortSignal
       });
       if (![200, 202, 204].includes(statusCode)) {
         const err = new Error();


### PR DESCRIPTION
I've swapped out the webhook requests with redirect tasks allowing the currently running application to be replaced immediately. This stops the race condition where both the currently running tasks webhook and the newly requested webhook could run in parallel.

Additionally, I've added an abortController to kill any in-flight request of the task being replaced.