### PR TITLE
Fix: REST dial timeout

### DIFF
--- a/lib/tasks/rest_dial.js
+++ b/lib/tasks/rest_dial.js
@@ -28,6 +28,7 @@ class TaskRestDial extends Task {
   */
   async exec(cs) {
     await super.exec(cs);
+    this.req = cs.req;
     this.canCancel = true;
 
     this._setCallTimer();
@@ -37,9 +38,9 @@ class TaskRestDial extends Task {
   kill(cs) {
     super.kill(cs);
     this._clearCallTimer();
-    if (this.canCancel && cs?.req) {
+    if (this.canCancel) {
       this.canCancel = false;
-      cs.req.cancel();
+      (cs ?? this).req?.cancel();
     }
     this.notifyTaskDone();
   }


### PR DESCRIPTION
This fixes a bug I introduced in #268 and addresses #343. When the call session isn't available, use the saved request to cancel.

I still need to check the handling of a 302, in the case of using the saved request to cancel.