### PR TITLE
Fix: Conference continuity

### DIFF
--- a/lib/tasks/conference.js
+++ b/lib/tasks/conference.js
@@ -114,7 +114,12 @@ class Conference extends Task {
     }
     this.emitter.emit('kill');
     await this._doFinalMemberCheck(cs);
-    if (this.ep && this.ep.connected) this.ep.conn.removeAllListeners('esl::event::CUSTOM::*') ;
+    if (this.ep && this.ep.connected) {
+      this.ep.conn.removeAllListeners('esl::event::CUSTOM::*');
+      this.ep.api(`conference ${this.confName} kick ${this.memberId}`)
+        .catch((err) => this.logger.info({err}, 'Error kicking participant'));
+    }
+    cs.clearConferenceDetails();
     this.notifyTaskDone();
   }
 


### PR DESCRIPTION
This addresses #349.

A caller couldn't enter more than one conference as the conference details weren't been cleared from Jambonz and FreeSWITCH.

The changes address the following issues:

- Stale conference data in Jambonz was causing the call to be hungup.
- Stale conference data in FreeSWITCH was causing one way audio (FreeSWITCH stops generating RTP).

The `clearConferenceDetails()` in `replaceEndpointAndEnd()` maybe redundant, but I wasn't sure about the order of events.

I'm unfamiliar with FreeSWITCH and the control channel. I assumed kicking the participant to clear the conference details was the correct thing to do.