### PR TITLE
Fix: REST dial timeout

### DIFF
--- a/lib/tasks/rest_dial.js
+++ b/lib/tasks/rest_dial.js
@@ -28,7 +28,7 @@ class TaskRestDial extends Task {
   */
   async exec(cs) {
     await super.exec(cs);
-    this.req = cs.req;
+    this.cs = cs;
     this.canCancel = true;
 
     this._setCallTimer();
@@ -40,7 +40,7 @@ class TaskRestDial extends Task {
     this._clearCallTimer();
     if (this.canCancel) {
       this.canCancel = false;
-      (cs ?? this).req?.cancel();
+      cs?.req?.cancel();
     }
     this.notifyTaskDone();
   }
@@ -99,7 +99,7 @@ class TaskRestDial extends Task {
   _onCallTimeout() {
     this.logger.debug('TaskRestDial: timeout expired without answer, killing task');
     this.timer = null;
-    this.kill();
+    this.kill(this.cs);
   }
 }
 

--- a/lib/tasks/rest_dial.js
+++ b/lib/tasks/rest_dial.js
@@ -28,6 +28,7 @@ class TaskRestDial extends Task {
   */
   async exec(cs) {
     await super.exec(cs);
+    this.req = cs.req;
     this.canCancel = true;
 
     this._setCallTimer();
@@ -37,9 +38,9 @@ class TaskRestDial extends Task {
   kill(cs) {
     super.kill(cs);
     this._clearCallTimer();
-    if (this.canCancel && cs?.req) {
+    if (this.canCancel) {
       this.canCancel = false;
-      cs.req.cancel();
+      (cs ?? this).req?.cancel();
     }
     this.notifyTaskDone();
   }


### PR DESCRIPTION
This fixes a bug I introduced in #268 and addresses #343. Save a copy of the call session to use in rest call task timeout.