### PR TITLE
When recordings are enabled, disable bidirectional audio

### DIFF
--- a/lib/session/call-session.js
+++ b/lib/session/call-session.js
@@ -1807,6 +1807,7 @@ class CallSession extends Emitter {
           username: JAMBONZ_RECORD_WS_USERNAME,
           password: JAMBONZ_RECORD_WS_PASSWORD
         },
+        disableBiDirectionalAudio: true,
         mixType : 'stereo',
         passDtmf: true
       };

--- a/lib/tasks/listen.js
+++ b/lib/tasks/listen.js
@@ -8,6 +8,7 @@ const DTMF_SPAN_NAME = 'dtmf';
 class TaskListen extends Task {
   constructor(logger, opts, parentTask) {
     super(logger, opts);
+    this.disableBidirectionalAudio = opts.disableBidirectionalAudio;
     this.preconditions = TaskPreconditions.Endpoint;
 
     [
@@ -154,7 +155,7 @@ class TaskListen extends Task {
     }
 
     /* support bi-directional audio */
-    if (!this.disableBiDirectionalAudio) {
+    if (!this.disableBidirectionalAudio) {
       ep.addCustomEventListener(ListenEvents.PlayAudio, this._onPlayAudio.bind(this, ep));
     }
     ep.addCustomEventListener(ListenEvents.KillAudio, this._onKillAudio.bind(this, ep));


### PR DESCRIPTION
When recordings are enabled, disable bidirectional audio on jambonz-session-record.
The flag was not being set on the constructor.