### PR TITLE
fix validation for alternative languages

### DIFF
--- a/lib/tasks/gather.js
+++ b/lib/tasks/gather.js
@@ -120,9 +120,10 @@ class TaskGather extends SttTask {
         'Gather:exec - applying global sttHints');
     }
     if (cs.hasAltLanguages) {
-      this.data.recognizer.altLanguages = this.data.recognizer.altLanguages.concat(cs.altLanguages);
-      this.logger.debug({altLanguages: this.data.recognizer?.altLanguages},
-        'Gather:exec - applying altLanguages');
+      if (this.data.recognizer?.altLanguages && Array.isArray(this.data.recognizer.altLanguages)) {
+        this.data.recognizer.altLanguages = this.data.recognizer.altLanguages.concat(cs.altLanguages);
+        this.logger.debug({ altLanguages: this.data.recognizer.altLanguages }, 'Gather:exec - applying altLanguages');
+      }
     }
     if (cs.hasGlobalSttPunctuation && !this.data.recognizer.punctuation) {
       this.data.recognizer.punctuation = cs.globalSttPunctuation;


### PR DESCRIPTION
I noticed some errors when setting an empty array of alternative languages, we have an error on concat function since the altLanguages can be undefined and the concat function does not work. This code will prevent this kind of error to happen, cause it was leading to miss a gather.