### PR TITLE
fix: transcribe 2 channels

### DIFF
--- a/lib/tasks/transcribe.js
+++ b/lib/tasks/transcribe.js
@@ -175,8 +175,8 @@ class TaskTranscribe extends SttTask {
   }
 
   async _setSpeechHandlers(cs, ep, channel) {
-    if (ep.speechHandlersSet) return;
-    ep.speechHandlersSet = true;
+    if (ep._speechHandlersSet) return;
+    ep._speechHandlersSet = true;
     const opts = this.setChannelVarsForStt(this, this.sttCredentials, this.data.recognizer);
     switch (this.vendor) {
       case 'google':

--- a/lib/tasks/transcribe.js
+++ b/lib/tasks/transcribe.js
@@ -175,8 +175,6 @@ class TaskTranscribe extends SttTask {
   }
 
   async _setSpeechHandlers(cs, ep, channel) {
-    if (this._speechHandlersSet) return;
-    this._speechHandlersSet = true;
     const opts = this.setChannelVarsForStt(this, this.sttCredentials, this.data.recognizer);
     switch (this.vendor) {
       case 'google':

--- a/lib/tasks/transcribe.js
+++ b/lib/tasks/transcribe.js
@@ -175,6 +175,8 @@ class TaskTranscribe extends SttTask {
   }
 
   async _setSpeechHandlers(cs, ep, channel) {
+    if (ep.speechHandlersSet) return;
+    ep.speechHandlersSet = true;
     const opts = this.setChannelVarsForStt(this, this.sttCredentials, this.data.recognizer);
     switch (this.vendor) {
       case 'google':


### PR DESCRIPTION
When dial transcribe is being use, feature server will request freeswitch 2 times for enable transcription for 2 different endpoints.

But due to this flag _speechHandlersSet, the seconds endpoint will not have speech credential for making connection to stt provider.

is there any idea why this flag is putting here and is there any regression if we remove this?