### PR TITLE
Add schema validation to create-call req.body, validate app_json via verb-specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jambones-feature-server ![Build Status](https://github.com/jambonz/jambonz-feature-server/workflows/CI/badge.svg)
+# jambonz-feature-server ![Build Status](https://github.com/jambonz/jambonz-feature-server/workflows/CI/badge.svg)
 
 This application implements the core feature server of the jambones platform.
 

--- a/lib/http-routes/api/create-call.js
+++ b/lib/http-routes/api/create-call.js
@@ -5,303 +5,323 @@ const CallInfo = require('../../session/call-info');
 const {CallDirection, CallStatus} = require('../../utils/constants');
 const uuidv4 = require('uuid-random');
 const SipError = require('drachtio-srf').SipError;
+const { validationResult } = require('express-validator');
+const { validate } = require('@jambonz/verb-specifications');
 const sysError = require('./error');
 const HttpRequestor = require('../../utils/http-requestor');
 const WsRequestor = require('../../utils/ws-requestor');
 const RootSpan = require('../../utils/call-tracer');
 const dbUtils = require('../../utils/db-utils');
 const { mergeSdpMedia, extractSdpMedia } = require('../../utils/sdp-utils');
+const { createCallSchema } = require('../schemas/create-call');
 
-router.post('/', async(req, res) => {
-  const {logger} = req.app.locals;
-  const accountSid = req.body.account_sid;
-  const {srf} = require('../../..');
-
-  logger.debug({body: req.body}, 'got createCall request');
-  try {
-    let uri, cs, to;
-    // app_json is creaeted by only api-server.
-    // if it available, take it and delete before creating task
-    const app_json = req.body.app_json;
-    delete req.body.app_json;
-    const restDial = makeTask(logger, {'rest:dial': req.body});
-    restDial.appJson = app_json;
-    const {lookupAccountDetails, lookupCarrierByPhoneNumber, lookupCarrier} = dbUtils(logger, srf);
-    const {
-      lookupAppBySid
-    }  = srf.locals.dbHelpers;
-    const {getSBC, getFreeswitch} = srf.locals;
-    const sbcAddress = getSBC();
-    if (!sbcAddress) throw new Error('no available SBCs for outbound call creation');
-    const target = restDial.to;
-    const opts = {
-      callingNumber: restDial.from,
-      ...(restDial.callerName && {callingName: restDial.callerName}),
-      headers: req.body.headers || {}
-    };
-
-
-    const {lookupTeamsByAccount, lookupAccountBySid} = srf.locals.dbHelpers;
-    const account = await lookupAccountBySid(req.body.account_sid);
-    const accountInfo = await lookupAccountDetails(req.body.account_sid);
-    const callSid = uuidv4();
-    const application = req.body.application_sid ? await lookupAppBySid(req.body.application_sid) : null;
-    const record_all_calls = account.record_all_calls || (application && application.record_all_calls);
-    const recordOutputFormat = account.record_format || 'mp3';
-    const rootSpan = new RootSpan('rest-call', {
-      callSid,
-      accountSid,
-      ...(req.body?.application_sid && {'X-Application-Sid': req.body.application_sid})
-    });
-
-    opts.headers = {
-      ...opts.headers,
-      'X-Jambonz-Routing': target.type,
-      'X-Jambonz-FS-UUID': srf.locals.fsUUID,
-      'X-Call-Sid': callSid,
-      'X-Account-Sid': accountSid,
-      'X-Trace-ID': rootSpan.traceId,
-      ...(req.body?.application_sid && {'X-Application-Sid': req.body.application_sid}),
-      ...(restDial.fromHost && {'X-Preferred-From-Host': restDial.fromHost}),
-      ...(record_all_calls && {'X-Record-All-Calls': recordOutputFormat})
-    };
-
-    switch (target.type) {
-      case 'phone':
-      case 'teams':
-        uri = `sip:${target.number}@${sbcAddress}`;
-        to = target.number;
-        if ('teams' === target.type) {
-          const obj = await lookupTeamsByAccount(accountSid);
-          if (!obj) throw new Error('dial to ms teams not allowed; account must first be configured with teams info');
-          Object.assign(opts.headers, {
-            'X-MS-Teams-FQDN': obj.ms_teams_fqdn,
-            'X-MS-Teams-Tenant-FQDN': target.tenant || obj.tenant_fqdn
-          });
-          if (target.vmail === true) uri = `${uri};opaque=app:voicemail`;
-        }
-        break;
-      case 'user':
-        uri = `sip:${target.name}`;
-        to = target.name;
-        if (target.overrideTo) {
-          Object.assign(opts.headers, {
-            'X-Override-To': target.overrideTo
-          });
-        }
-        break;
-      case 'sip':
-        uri = target.sipUri;
-        to = uri;
-        break;
+router.post('/',
+  createCallSchema,
+  async(req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
     }
+    const {logger} = req.app.locals;
+    const accountSid = req.body.account_sid;
+    const {srf} = require('../../..');
 
-    if (target.type === 'phone' && target.trunk) {
-      const voip_carrier_sid = await lookupCarrier(req.body.account_sid, target.trunk);
-      logger.info(
-        `createCall: selected ${voip_carrier_sid} for requested carrier: ${target.trunk || 'unspecified'})`);
-      if (voip_carrier_sid) {
-        opts.headers['X-Requested-Carrier-Sid'] = voip_carrier_sid;
+    const app_json = req.body['app_json'];
+    try {
+    // app_json is created only by api-server.
+      if (app_json) {
+        // if available, delete from req before creating task
+        delete req.body.app_json;
+        // validate possible app_json via verb-specifications
+        validate(logger, JSON.parse(app_json));
       }
+    } catch (err) {
+      logger.debug({ err }, `invalid app_json: ${err.message}`);
     }
 
-    /**
+    logger.debug({body: req.body}, 'got createCall request');
+    try {
+      let uri, cs, to;
+
+      const restDial = makeTask(logger, { 'rest:dial': req.body });
+      restDial.appJson = app_json;
+
+      const {lookupAccountDetails, lookupCarrierByPhoneNumber, lookupCarrier} = dbUtils(logger, srf);
+      const {
+        lookupAppBySid
+      }  = srf.locals.dbHelpers;
+      const {getSBC, getFreeswitch} = srf.locals;
+      const sbcAddress = getSBC();
+      if (!sbcAddress) throw new Error('no available SBCs for outbound call creation');
+      const target = restDial.to;
+      const opts = {
+        callingNumber: restDial.from,
+        ...(restDial.callerName && {callingName: restDial.callerName}),
+        headers: req.body.headers || {}
+      };
+
+
+      const {lookupTeamsByAccount, lookupAccountBySid} = srf.locals.dbHelpers;
+      const account = await lookupAccountBySid(req.body.account_sid);
+      const accountInfo = await lookupAccountDetails(req.body.account_sid);
+      const callSid = uuidv4();
+      const application = req.body.application_sid ? await lookupAppBySid(req.body.application_sid) : null;
+      const record_all_calls = account.record_all_calls || (application && application.record_all_calls);
+      const recordOutputFormat = account.record_format || 'mp3';
+      const rootSpan = new RootSpan('rest-call', {
+        callSid,
+        accountSid,
+        ...(req.body?.application_sid && {'X-Application-Sid': req.body.application_sid})
+      });
+
+      opts.headers = {
+        ...opts.headers,
+        'X-Jambonz-Routing': target.type,
+        'X-Jambonz-FS-UUID': srf.locals.fsUUID,
+        'X-Call-Sid': callSid,
+        'X-Account-Sid': accountSid,
+        'X-Trace-ID': rootSpan.traceId,
+        ...(req.body?.application_sid && {'X-Application-Sid': req.body.application_sid}),
+        ...(restDial.fromHost && {'X-Preferred-From-Host': restDial.fromHost}),
+        ...(record_all_calls && {'X-Record-All-Calls': recordOutputFormat})
+      };
+
+      switch (target.type) {
+        case 'phone':
+        case 'teams':
+          uri = `sip:${target.number}@${sbcAddress}`;
+          to = target.number;
+          if ('teams' === target.type) {
+            const obj = await lookupTeamsByAccount(accountSid);
+            if (!obj) throw new Error('dial to ms teams not allowed; account must first be configured with teams info');
+            Object.assign(opts.headers, {
+              'X-MS-Teams-FQDN': obj.ms_teams_fqdn,
+              'X-MS-Teams-Tenant-FQDN': target.tenant || obj.tenant_fqdn
+            });
+            if (target.vmail === true) uri = `${uri};opaque=app:voicemail`;
+          }
+          break;
+        case 'user':
+          uri = `sip:${target.name}`;
+          to = target.name;
+          if (target.overrideTo) {
+            Object.assign(opts.headers, {
+              'X-Override-To': target.overrideTo
+            });
+          }
+          break;
+        case 'sip':
+          uri = target.sipUri;
+          to = uri;
+          break;
+      }
+
+      if (target.type === 'phone' && target.trunk) {
+        const voip_carrier_sid = await lookupCarrier(req.body.account_sid, target.trunk);
+        logger.info(
+          `createCall: selected ${voip_carrier_sid} for requested carrier: ${target.trunk || 'unspecified'})`);
+        if (voip_carrier_sid) {
+          opts.headers['X-Requested-Carrier-Sid'] = voip_carrier_sid;
+        }
+      }
+
+      /**
      * trunk isn't specified,
      * check if from-number matches any existing numbers on Jambonz
      *  */
-    if (target.type === 'phone' && !target.trunk) {
-      const str = restDial.from || '';
-      const callingNumber = str.startsWith('+') ? str.substring(1) : str;
-      const voip_carrier_sid = await lookupCarrierByPhoneNumber(req.body.account_sid, callingNumber);
-      logger.info(
-        `createCall: selected ${voip_carrier_sid} for requested phone number: ${callingNumber || 'unspecified'})`);
-      if (voip_carrier_sid) {
-        opts.headers['X-Requested-Carrier-Sid'] = voip_carrier_sid;
-      }
-    }
-
-    /* create endpoint for outdial */
-    const ms = getFreeswitch();
-    if (!ms) throw new Error('no available Freeswitch for outbound call creation');
-    const ep = await ms.createEndpoint();
-    logger.debug(`createCall: successfully allocated endpoint, sending INVITE to ${sbcAddress}`);
-
-    /* launch outdial */
-    let sdp, sipLogger;
-    let dualEp;
-    let localSdp = ep.local.sdp;
-
-    if (req.body.dual_streams) {
-      dualEp = await ms.createEndpoint();
-      localSdp = mergeSdpMedia(localSdp, dualEp.local.sdp);
-    }
-
-    const connectStream = async(remoteSdp) => {
-      if (remoteSdp !== sdp) {
-        sdp = remoteSdp;
-        if (req.body.dual_streams) {
-          const [sdpLegA, sdpLebB] = extractSdpMedia(remoteSdp);
-
-          await ep.modify(sdpLegA);
-          await dualEp.modify(sdpLebB);
-          await ep.bridge(dualEp);
-        } else {
-          ep.modify(sdp);
+      if (target.type === 'phone' && !target.trunk) {
+        const str = restDial.from || '';
+        const callingNumber = str.startsWith('+') ? str.substring(1) : str;
+        const voip_carrier_sid = await lookupCarrierByPhoneNumber(req.body.account_sid, callingNumber);
+        logger.info(
+          `createCall: selected ${voip_carrier_sid} for requested phone number: ${callingNumber || 'unspecified'})`);
+        if (voip_carrier_sid) {
+          opts.headers['X-Requested-Carrier-Sid'] = voip_carrier_sid;
         }
-        return true;
       }
-      return false;
-    };
-    Object.assign(opts, {
-      proxy: `sip:${sbcAddress}`,
-      localSdp
-    });
-    if (target.auth) opts.auth = target.auth;
+
+      /* create endpoint for outdial */
+      const ms = getFreeswitch();
+      if (!ms) throw new Error('no available Freeswitch for outbound call creation');
+      const ep = await ms.createEndpoint();
+      logger.debug(`createCall: successfully allocated endpoint, sending INVITE to ${sbcAddress}`);
+
+      /* launch outdial */
+      let sdp, sipLogger;
+      let dualEp;
+      let localSdp = ep.local.sdp;
+
+      if (req.body.dual_streams) {
+        dualEp = await ms.createEndpoint();
+        localSdp = mergeSdpMedia(localSdp, dualEp.local.sdp);
+      }
+
+      const connectStream = async(remoteSdp) => {
+        if (remoteSdp !== sdp) {
+          sdp = remoteSdp;
+          if (req.body.dual_streams) {
+            const [sdpLegA, sdpLebB] = extractSdpMedia(remoteSdp);
+
+            await ep.modify(sdpLegA);
+            await dualEp.modify(sdpLebB);
+            await ep.bridge(dualEp);
+          } else {
+            ep.modify(sdp);
+          }
+          return true;
+        }
+        return false;
+      };
+      Object.assign(opts, {
+        proxy: `sip:${sbcAddress}`,
+        localSdp
+      });
+      if (target.auth) opts.auth = target.auth;
 
 
-    /**
+      /**
      * create our application object -
      * not from the database as per an inbound call,
      * but from the provided params in the request
      */
-    const app = req.body;
+      const app = req.body;
 
-    /**
+      /**
      * attach our requestor and notifier objects
      * these will be used for all http requests we make during this call
      */
-    if ('WS' === app.call_hook?.method || /^wss?:/.test(app.call_hook.url)) {
-      logger.debug({call_hook: app.call_hook}, 'creating websocket for call hook');
-      app.requestor = new WsRequestor(logger, account.account_sid, app.call_hook, account.webhook_secret) ;
-      if (app.call_hook.url === app.call_status_hook.url  || !app.call_status_hook?.url) {
-        logger.debug('reusing websocket for call status hook');
-        app.notifier = app.requestor;
+      if ('WS' === app.call_hook?.method || /^wss?:/.test(app.call_hook.url)) {
+        logger.debug({call_hook: app.call_hook}, 'creating websocket for call hook');
+        app.requestor = new WsRequestor(logger, account.account_sid, app.call_hook, account.webhook_secret) ;
+        if (app.call_hook.url === app.call_status_hook.url  || !app.call_status_hook?.url) {
+          logger.debug('reusing websocket for call status hook');
+          app.notifier = app.requestor;
+        }
       }
-    }
-    else {
-      logger.debug({call_hook: app.call_hook}, 'creating http client for call hook');
-      app.requestor = new HttpRequestor(logger, account.account_sid, app.call_hook, account.webhook_secret);
-    }
-    if (!app.notifier && app.call_status_hook) {
-      app.notifier = new HttpRequestor(logger, account.account_sid, app.call_status_hook, account.webhook_secret);
-      logger.debug({call_hook: app.call_hook}, 'creating http client for call status hook');
-    }
-    else if (!app.notifier) {
-      logger.debug('creating null call status hook');
-      app.notifier = {request: () => {}, close: () => {}};
-    }
+      else {
+        logger.debug({call_hook: app.call_hook}, 'creating http client for call hook');
+        app.requestor = new HttpRequestor(logger, account.account_sid, app.call_hook, account.webhook_secret);
+      }
+      if (!app.notifier && app.call_status_hook) {
+        app.notifier = new HttpRequestor(logger, account.account_sid, app.call_status_hook, account.webhook_secret);
+        logger.debug({call_hook: app.call_hook}, 'creating http client for call status hook');
+      }
+      else if (!app.notifier) {
+        logger.debug('creating null call status hook');
+        app.notifier = {request: () => {}, close: () => {}};
+      }
 
-    /* now launch the outdial */
-    try {
-      const dlg = await srf.createUAC(uri, {...opts,  followRedirects: true, keepUriOnRedirect: true}, {
-        cbRequest: (err, inviteReq) => {
+      /* now launch the outdial */
+      try {
+        const dlg = await srf.createUAC(uri, {...opts,  followRedirects: true, keepUriOnRedirect: true}, {
+          cbRequest: (err, inviteReq) => {
           /* in case of 302 redirect, this gets called twice, ignore the second
               except to update the req so that it can later be canceled if need be
           */
-          if (res.headersSent) {
-            logger.info(`create-call: got redirect, updating request to new call-id ${req.get('Call-ID')}`);
-            if (cs) cs.req = inviteReq;
-            return;
+            if (res.headersSent) {
+              logger.info(`create-call: got redirect, updating request to new call-id ${req.get('Call-ID')}`);
+              if (cs) cs.req = inviteReq;
+              return;
+            }
+
+            if (err) {
+              logger.error(err, 'createCall Error creating call');
+              res.status(500).send('Call Failure');
+              return;
+            }
+            inviteReq.srf = srf;
+            inviteReq.locals = {
+              ...(inviteReq || {}),
+              callSid,
+              application_sid: app.application_sid
+            };
+            /* ok our outbound INVITE is in flight */
+
+            const tasks = [restDial];
+            sipLogger = logger.child({
+              callSid,
+              callId: inviteReq.get('Call-ID'),
+              accountSid,
+              traceId: rootSpan.traceId
+            });
+            app.requestor.logger = app.notifier.logger = sipLogger;
+            const callInfo = new CallInfo({
+              direction: CallDirection.Outbound,
+              req: inviteReq,
+              to,
+              tag: app.tag,
+              callSid,
+              accountSid: req.body.account_sid,
+              applicationSid: app.application_sid,
+              traceId: rootSpan.traceId
+            });
+            cs = new RestCallSession({
+              logger: sipLogger,
+              application: app,
+              srf,
+              req: inviteReq,
+              ep,
+              ep2: dualEp,
+              tasks,
+              callInfo,
+              accountInfo,
+              rootSpan
+            });
+            cs.exec(req);
+
+            res.status(201).json({sid: cs.callSid, callId: inviteReq.get('Call-ID')});
+
+            sipLogger.info({sid: cs.callSid, callId: inviteReq.get('Call-ID')},
+              `outbound REST call attempt to ${JSON.stringify(target)} has been sent`);
+          },
+          cbProvisional: (prov) => {
+            const callStatus = prov.body ? CallStatus.EarlyMedia : CallStatus.Ringing;
+            if ([180, 183].includes(prov.status) && prov.body) connectStream(prov.body);
+            restDial.emit('callStatus', prov.status, !!prov.body);
+            cs.emit('callStatusChange', {callStatus, sipStatus: prov.status});
           }
-
-          if (err) {
-            logger.error(err, 'createCall Error creating call');
-            res.status(500).send('Call Failure');
-            return;
-          }
-          inviteReq.srf = srf;
-          inviteReq.locals = {
-            ...(inviteReq || {}),
-            callSid,
-            application_sid: app.application_sid
-          };
-          /* ok our outbound INVITE is in flight */
-
-          const tasks = [restDial];
-          sipLogger = logger.child({
-            callSid,
-            callId: inviteReq.get('Call-ID'),
-            accountSid,
-            traceId: rootSpan.traceId
+        });
+        connectStream(dlg.remote.sdp);
+        cs.emit('callStatusChange', {
+          callStatus: CallStatus.InProgress,
+          sipStatus: 200,
+          sipReason: 'OK'
+        });
+        restDial.emit('callStatus', 200);
+        restDial.emit('connect', dlg);
+      }
+      catch (err) {
+        let callStatus = CallStatus.Failed;
+        if (err instanceof SipError) {
+          if ([486, 603].includes(err.status)) callStatus = CallStatus.Busy;
+          else if (487 === err.status) callStatus = CallStatus.NoAnswer;
+          if (sipLogger) sipLogger.info(`REST outdial failed with ${err.status}`);
+          else console.log(`REST outdial failed with ${err.status}`);
+          if (cs) cs.emit('callStatusChange', {
+            callStatus,
+            sipStatus: err.status,
+            sipReason: err.reason
           });
-          app.requestor.logger = app.notifier.logger = sipLogger;
-          const callInfo = new CallInfo({
-            direction: CallDirection.Outbound,
-            req: inviteReq,
-            to,
-            tag: app.tag,
-            callSid,
-            accountSid: req.body.account_sid,
-            applicationSid: app.application_sid,
-            traceId: rootSpan.traceId
-          });
-          cs = new RestCallSession({
-            logger: sipLogger,
-            application: app,
-            srf,
-            req: inviteReq,
-            ep,
-            ep2: dualEp,
-            tasks,
-            callInfo,
-            accountInfo,
-            rootSpan
-          });
-          cs.exec(req);
-
-          res.status(201).json({sid: cs.callSid, callId: inviteReq.get('Call-ID')});
-
-          sipLogger.info({sid: cs.callSid, callId: inviteReq.get('Call-ID')},
-            `outbound REST call attempt to ${JSON.stringify(target)} has been sent`);
-        },
-        cbProvisional: (prov) => {
-          const callStatus = prov.body ? CallStatus.EarlyMedia : CallStatus.Ringing;
-          if ([180, 183].includes(prov.status) && prov.body) connectStream(prov.body);
-          restDial.emit('callStatus', prov.status, !!prov.body);
-          cs.emit('callStatusChange', {callStatus, sipStatus: prov.status});
+          cs.callGone = true;
         }
-      });
-      connectStream(dlg.remote.sdp);
-      cs.emit('callStatusChange', {
-        callStatus: CallStatus.InProgress,
-        sipStatus: 200,
-        sipReason: 'OK'
-      });
-      restDial.emit('callStatus', 200);
-      restDial.emit('connect', dlg);
+        else {
+          if (cs) cs.emit('callStatusChange', {
+            callStatus,
+            sipStatus: 500,
+            sipReason: 'Internal Server Error'
+          });
+          if (sipLogger) sipLogger.error({err}, 'REST outdial failed');
+          else console.error(err);
+        }
+        ep.destroy();
+        if (dualEp) {
+          dualEp.destroy();
+        }
+        setTimeout(restDial.kill.bind(restDial, cs), 5000);
+      }
+    } catch (err) {
+      sysError(logger, res, err);
     }
-    catch (err) {
-      let callStatus = CallStatus.Failed;
-      if (err instanceof SipError) {
-        if ([486, 603].includes(err.status)) callStatus = CallStatus.Busy;
-        else if (487 === err.status) callStatus = CallStatus.NoAnswer;
-        if (sipLogger) sipLogger.info(`REST outdial failed with ${err.status}`);
-        else console.log(`REST outdial failed with ${err.status}`);
-        if (cs) cs.emit('callStatusChange', {
-          callStatus,
-          sipStatus: err.status,
-          sipReason: err.reason
-        });
-        cs.callGone = true;
-      }
-      else {
-        if (cs) cs.emit('callStatusChange', {
-          callStatus,
-          sipStatus: 500,
-          sipReason: 'Internal Server Error'
-        });
-        if (sipLogger) sipLogger.error({err}, 'REST outdial failed');
-        else console.error(err);
-      }
-      ep.destroy();
-      if (dualEp) {
-        dualEp.destroy();
-      }
-      setTimeout(restDial.kill.bind(restDial, cs), 5000);
-    }
-  } catch (err) {
-    sysError(logger, res, err);
-  }
-});
+  });
 
 module.exports = router;

--- a/lib/http-routes/schemas/create-call.js
+++ b/lib/http-routes/schemas/create-call.js
@@ -1,0 +1,114 @@
+const { checkSchema } = require('express-validator');
+
+/**
+ * @path api-server {{base_url}}/v1/Accounts/:account_sid/Calls
+ * @see https://api.jambonz.org/#243a2edd-7999-41db-bd0d-08082bbab401
+ */
+const createCallSchema = checkSchema({
+  application_sid: {
+    isString: true,
+    optional: true,
+    isLength: { options: { min: 36, max: 36 } },
+    errorMessage: 'Invalid application_sid',
+  },
+  answerOnBridge: {
+    isBoolean: true,
+    optional: true,
+    errorMessage: 'Invalid answerOnBridge',
+  },
+  from: {
+    errorMessage: 'Invalid from',
+    isString: true,
+    isLength: {
+      options: { min: 1, max: 256 },
+    },
+  },
+  fromHost: {
+    isString: true,
+    optional: true,
+    errorMessage: 'Invalid fromHost',
+  },
+  to: {
+    errorMessage: 'Invalid to',
+    isObject: true,
+  },
+  callerName: {
+    isString: true,
+    optional: true,
+    errorMessage: 'Invalid callerName',
+  },
+  amd: {
+    isObject: true,
+    optional: true,
+  },
+  tag: {
+    isObject: true,
+    optional: true,
+    errorMessage: 'Invalid tag',
+  },
+  'tag.*': {
+    trim: true,
+    escape: true,
+    stripLow: true,
+  },
+  app_json: {
+    isString: true,
+    optional: true,
+    errorMessage: 'Invalid app_json',
+  },
+  account_sid: {
+    isString: true,
+    optional: true,
+    errorMessage: 'Invalid account_sid',
+    isLength: { options: { min: 36, max: 36 } },
+  },
+  timeout: {
+    isInt: true,
+    optional: true,
+    errorMessage: 'Invalid timeout',
+  },
+  timeLimit: {
+    isInt: true,
+    optional: true,
+    errorMessage: 'Invalid timeLimit',
+  },
+  call_hook: {
+    isObject: true,
+    optional: true,
+    errorMessage: 'Invalid call_hook',
+  },
+  call_status_hook: {
+    isObject: true,
+    optional: true,
+    errorMessage: 'Invalid call_status_hook',
+  },
+  speech_synthesis_vendor: {
+    isString: true,
+    optional: true,
+    errorMessage: 'Invalid speech_synthesis_vendor',
+  },
+  speech_synthesis_language: {
+    isString: true,
+    optional: true,
+    errorMessage: 'Invalid speech_synthesis_language',
+  },
+  speech_synthesis_voice: {
+    isString: true,
+    optional: true,
+    errorMessage: 'Invalid speech_synthesis_voice',
+  },
+  speech_recognizer_vendor: {
+    isString: true,
+    optional: true,
+    errorMessage: 'Invalid speech_recognizer_vendor',
+  },
+  speech_recognizer_language: {
+    isString: true,
+    optional: true,
+    errorMessage: 'Invalid speech_recognizer_language',
+  }
+}, ['body']);
+
+module.exports = {
+  createCallSchema
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "drachtio-fsmrf": "^3.0.27",
         "drachtio-srf": "^4.5.29",
         "express": "^4.18.2",
+        "express-validator": "^7.0.1",
         "ip": "^1.1.8",
         "moment": "^2.29.4",
         "parse-url": "^8.1.0",
@@ -5836,6 +5837,18 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.0.1.tgz",
+      "integrity": "sha512-oB+z9QOzQIE8FnlINqyIFA8eIckahC6qc8KtqLdLJcU3/phVyuhXH3bA4qzcrhme+1RYaCSwrq+TlZ/kAKIARA==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "^13.9.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -10237,6 +10250,14 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -15184,6 +15205,15 @@
         }
       }
     },
+    "express-validator": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.0.1.tgz",
+      "integrity": "sha512-oB+z9QOzQIE8FnlINqyIFA8eIckahC6qc8KtqLdLJcU3/phVyuhXH3bA4qzcrhme+1RYaCSwrq+TlZ/kAKIARA==",
+      "requires": {
+        "lodash": "^4.17.21",
+        "validator": "^13.9.0"
+      }
+    },
     "ext": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
@@ -18477,6 +18507,11 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "drachtio-fsmrf": "^3.0.27",
     "drachtio-srf": "^4.5.29",
     "express": "^4.18.2",
+    "express-validator": "^7.0.1",
     "ip": "^1.1.8",
     "moment": "^2.29.4",
     "parse-url": "^8.1.0",


### PR DESCRIPTION
# Issue

We get a Snyk - high severity issue when scanning the feature-server via code analysis: **H Code Injection**

![Screenshot from 2023-10-18 11-20-58](https://github.com/jambonz/jambonz-feature-server/assets/6165055/c8d66cec-ec6d-4a59-bbcf-77bf002bc3f7)


_Unsanitized input from the HTTP request body flows into setTimeout, where it is executed as JavaScript code. This may result in a Code Injection vulnerability._
`/lib/http-routes/api/create-call.js`
 
To avoid any attacks I would recommend to:
- Add schema-validation to the req.body (especially escape 'tag') property via express-validator
- Validate the property `app_json` by the usage of the verb-specifications `validation`

Snyk vulnerability
[CWE-94](https://cwe.mitre.org/data/definitions/94.html)


This PR won't fix the issue on Snyk, but we'd be able to ignore the vulnerability with a reason, that a attack is not possible with this approach.