### PR TITLE
enqueue: allow tag verb for waithook

### DIFF
--- a/lib/tasks/enqueue.js
+++ b/lib/tasks/enqueue.js
@@ -311,7 +311,8 @@ class TaskEnqueue extends Task {
     }
   }
 
-  async _playHook(cs, dlg, hook, allowed = [TaskName.Play, TaskName.Say, TaskName.Pause, TaskName.Leave]) {
+  async _playHook(cs, dlg, hook,
+    allowed = [TaskName.Play, TaskName.Say, TaskName.Pause, TaskName.Leave, TaskName.Tag]) {
     const {sortedSetLength, sortedSetPositionByPattern} = cs.srf.locals.dbHelpers;
     const b3 = this.getTracingPropagation();
     const httpHeaders = b3 && {b3};
@@ -331,6 +332,7 @@ class TaskEnqueue extends Task {
         queuePosition: queuePosition.length ? queuePosition[0] : 0,
         callSid: this.cs.callSid,
         callId: this.cs.callId,
+        customerData: this.cs.callInfo.customerData
       });
     } catch (err) {
       this.logger.error({err}, `TaskEnqueue:_playHook error retrieving list info for queue ${this.queueName}`);


### PR DESCRIPTION
Changes:

- Allow tag verb for waithook
- Attach customer data object on sending to global queue webhook