### PR TITLE
Add a custom sanitization function for the "Tag" property

### DIFF
--- a/lib/http-routes/api/create-call.js
+++ b/lib/http-routes/api/create-call.js
@@ -5,7 +5,7 @@ const CallInfo = require('../../session/call-info');
 const {CallDirection, CallStatus} = require('../../utils/constants');
 const uuidv4 = require('uuid-random');
 const SipError = require('drachtio-srf').SipError;
-const { validationResult } = require('express-validator');
+const { validationResult, body } = require('express-validator');
 const { validate } = require('@jambonz/verb-specifications');
 const sysError = require('./error');
 const HttpRequestor = require('../../utils/http-requestor');
@@ -13,7 +13,7 @@ const WsRequestor = require('../../utils/ws-requestor');
 const RootSpan = require('../../utils/call-tracer');
 const dbUtils = require('../../utils/db-utils');
 const { mergeSdpMedia, extractSdpMedia } = require('../../utils/sdp-utils');
-const { createCallSchema } = require('../schemas/create-call');
+const { createCallSchema, customSanitizeFunction } = require('../schemas/create-call');
 
 const removeNullProperties = (obj) => (Object.keys(obj).forEach((key) => obj[key] === null && delete obj[key]), obj);
 const removeNulls = (req, res, next) => {
@@ -24,6 +24,12 @@ const removeNulls = (req, res, next) => {
 router.post('/',
   removeNulls,
   createCallSchema,
+  body('tag').custom((value) => {
+    if (value) {
+      customSanitizeFunction(value);
+    }
+    return true;
+  }),
   async(req, res) => {
     const {logger} = req.app.locals;
     const errors = validationResult(req);

--- a/lib/http-routes/schemas/create-call.js
+++ b/lib/http-routes/schemas/create-call.js
@@ -109,6 +109,26 @@ const createCallSchema = checkSchema({
   }
 }, ['body']);
 
+const customSanitizeFunction = (value) => {
+  try {
+    if (Array.isArray(value)) {
+      value = value.map((item) => customSanitizeFunction(item));
+    } else if (typeof value === 'object') {
+      Object.keys(value).forEach((key) => {
+        value[key] = customSanitizeFunction(value[key]);
+      });
+    } else if (typeof value === 'string') {
+      /* trims characters at the beginning and at the end of a string */
+      value = value.trim();
+      /* replaces <, >, &, ', " and / with their corresponding HTML entities */
+      value = escape(value);
+    }
+  } catch (error) {	}
+
+  return value;
+};
+
 module.exports = {
-  createCallSchema
+  createCallSchema,
+  customSanitizeFunction
 };

--- a/lib/http-routes/schemas/create-call.js
+++ b/lib/http-routes/schemas/create-call.js
@@ -46,11 +46,6 @@ const createCallSchema = checkSchema({
     optional: true,
     errorMessage: 'Invalid tag',
   },
-  'tag.*': {
-    trim: true,
-    escape: true,
-    stripLow: true,
-  },
   app_json: {
     isString: true,
     optional: true,


### PR DESCRIPTION
This PR fixed an issue, that with the current approach of schema validation with express-validator, 
nested `tag` objects result in `[Object object]

Changes:
- Removes "tag.*" from schema validation
- Add custom sanitizer function for body property "tag"
- In this sanitizer function strings are being escaped and trimmed
=> "tag" can contain nested objects that get sanitized

## How to reproduce the issue:
1. send a request to FS  `localhost:3000/v1/createCall`
```json
{
    "application_sid": "<valid_app_sid>",
    "from": "49123456789",
    "to": {
        "type": "phone",
        "number": "49123456789"
    },
    "call_hook": {
        "url": "http://127.0.0.1:3100/",
        "method": "POST"
    },
    "tag": {
        "env": "DEVELOPMENT",
        "array": [1, "https://vg.ai", { "foo": "     bar             "}],
        "processId": "ABCDE3051531764261-035",
        "Customer": {
            "firstName": "Mary      ",
            "email": "mary.popp@ins.fiction.com",
            "url": "http://127.0.0.1:3100/"
        }
    }
}
```


This results in 
```
{
"tag": {
            "env": "DEVELOPMENT",
            "array": [
                "1",
                "https:&#x2F;&#x2F;vg.ai",
                "[object Object]"
            ],
            "processId": "ABCDE3051531764261-035",
            "Customer": "[object Object]"
        }
}
```

## Tag after this PR

```json
"tag": {
            "env": "DEVELOPMENT",
            "array": [
                1,
                "https%3A//vg.ai",
                {
                    "foo": "bar"
                }
            ],
            "processId": "ABCDE3051531764261-035",
            "Customer": {
                "firstName": "Mary",
                "email": "mary.popp@ins.fiction.com",
                "url": "http%3A//127.0.0.1%3A3100/"
            }
        }
```


