### PR TITLE
Create Call: do not escape req.body.tag

### DIFF
--- a/lib/http-routes/schemas/create-call.js
+++ b/lib/http-routes/schemas/create-call.js
@@ -116,12 +116,9 @@ const customSanitizeFunction = (value) => {
       /* trims characters at the beginning and at the end of a string */
       value = value.trim();
 
-      /* We don't escape URLs but verify them via new URL */
+      /* Verify strings including 'http' via new URL */
       if (value.includes('http')) {
         value = new URL(value).toString();
-      } else {
-        /* replaces <, >, &, ', " and / with their corresponding HTML entities */
-        value = escape(value);
       }
     }
   } catch (error) {


### PR DESCRIPTION
Right now we are escaping each property value of req.body.tag when it's a string.

This leads to issues when e.g. using German umlauts.

So we should not escape anything within `tag`