### PR TITLE
Feature/add synth options call session

### DIFF
--- a/lib/tasks/config.js
+++ b/lib/tasks/config.js
@@ -138,6 +138,7 @@ class TaskConfig extends Task {
       cs.speechSynthesisVoice = this.synthesizer.voice !== 'default'
         ? this.synthesizer.voice
         : cs.speechSynthesisVoice;
+      cs.speechSynthesisOptions = this.synthesizer.options || cs.speechSynthesisOptions;
 
       // fallback vendor
       cs.fallbackSpeechSynthesisVendor = this.synthesizer.fallbackVendor !== 'default'

--- a/lib/tasks/say.js
+++ b/lib/tasks/say.js
@@ -68,6 +68,12 @@ class TaskSay extends Task {
     const salt = cs.callSid;
 
     let credentials = cs.getSpeechCredentials(vendor, 'tts', label);
+
+    /* override Synthesizer options from call session (via config verb) */
+    if (Object.keys(this.options).length === 0 && cs.speechSynthesisOptions && Object.keys(cs.speechSynthesisOptions).length > 0) {
+      this.options = cs.speechSynthesisOptions;
+    }
+
     /* parse Nuance voices into name and model */
     let model;
     if (vendor === 'nuance' && voice) {
@@ -95,11 +101,6 @@ class TaskSay extends Task {
       credentials.optimize_streaming_latency = this.options.optimize_streaming_latency
       || credentials.optimize_streaming_latency;
       voice = this.options.voice_id || voice;
-    }
-
-    /* override Synthesizer options from call session (via config verb) */
-    if (Object.keys(this.options).length === 0 && cs.speechSynthesisOptions && Object.keys(cs.speechSynthesisOptions).length > 0) {
-      this.options = cs.speechSynthesisOptions;
     }
 
     if (!preCache) this.logger.info({vendor, language, voice, model}, 'TaskSay:exec');

--- a/lib/tasks/say.js
+++ b/lib/tasks/say.js
@@ -97,6 +97,11 @@ class TaskSay extends Task {
       voice = this.options.voice_id || voice;
     }
 
+    /* override Synthesizer options from call session (via config verb) */
+    if (Object.keys(this.options).length === 0 && cs.speechSynthesisOptions && Object.keys(cs.speechSynthesisOptions).length > 0) {
+      this.options = cs.speechSynthesisOptions;
+    }
+
     if (!preCache) this.logger.info({vendor, language, voice, model}, 'TaskSay:exec');
     try {
       if (!credentials) {


### PR DESCRIPTION
Based on this PR #590 

- Add `speechSynthesisOptions` from config verb to a Call Session
- In say task: if defined, apply the `speechSynthesisOptions` to `this.options` - but let them get overwritten by `say.synthesizer.options`