### PR TITLE
Fix dequeue

### DIFF
--- a/lib/tasks/dequeue.js
+++ b/lib/tasks/dequeue.js
@@ -73,7 +73,8 @@ class TaskDequeue extends Task {
         try {
           let url;
           if (this.callSid) {
-            url = await retrieveByPatternSortedSet(this.queueName, `*${this.callSid}`);
+            const r = await retrieveByPatternSortedSet(this.queueName, `*${this.callSid}`);
+            url = r[0];
           } else {
             url = await retrieveFromSortedSet(this.queueName);
           }


### PR DESCRIPTION
The **retrieveByPatternSortedSet** returns an array that is always true even though its empty. As result the url is an empty string that breaks the dequeue task.

How to reproduce:
- Run the dequeue tasks for unexisting call 