### PR TITLE
Improve Deepgram default models by language

### DIFF
--- a/lib/utils/transcription-utils.js
+++ b/lib/utils/transcription-utils.js
@@ -102,6 +102,9 @@ const stickyVars = {
   ]
 };
 
+/**
+ * @see https://developers.deepgram.com/docs/models-languages-overview
+ */
 const optimalDeepramModels = {
   zh: ['base', 'base'],
   'zh-CN':['base', 'base'],
@@ -109,34 +112,34 @@ const optimalDeepramModels = {
   da: ['enhanced', 'enhanced'],
   en: ['nova-2-phonecall', 'nova-2'],
   'en-US': ['nova-2-phonecall', 'nova-2'],
-  'en-AU': ['nova-2-phonecall', 'nova-2'],
-  'en-GB': ['nova-2-phonecall', 'nova-2'],
-  'en-IN': ['nova-2-phonecall', 'nova-2'],
-  'en-NZ': ['nova-2-phonecall', 'nova-2'],
-  nl: ['nova-2-phonecall', 'nova-2'],
-  fr: ['nova-2-phonecall', 'nova-2'],
-  'fr-CA': ['nova-2-phonecall', 'nova-2'],
-  de: ['nova-2-phonecall', 'nova-2'],
-  hi: ['nova-2-phonecall', 'nova-2'],
-  'hi-Latn': ['nova-2-phonecall', 'nova-2'],
+  'en-AU': ['nova-2', 'nova-2'],
+  'en-GB': ['nova-2', 'nova-2'],
+  'en-IN': ['nova-2', 'nova-2'],
+  'en-NZ': ['nova-2', 'nova-2'],
+  nl: ['nova-2', 'nova-2'],
+  fr: ['nova-2', 'nova-2'],
+  'fr-CA': ['nova-2', 'nova-2'],
+  de: ['nova-2', 'nova-2'],
+  hi: ['nova-2', 'nova-2'],
+  'hi-Latn': ['nova-2', 'nova-2'],
   id: ['base', 'base'],
-  it: ['enhanced', 'enhanced'],
+  it: ['nova-2', 'nova-2'],
   ja: ['enhanced', 'enhanced'],
-  ko: ['enhanced', 'enhanced'],
-  no: ['enhanced', 'enhanced'],
-  pl: ['enhanced', 'enhanced'],
-  pt: ['nova-2-phonecall', 'nova-2'],
-  'pt-BR': ['nova-2-phonecall', 'nova-2'],
-  'pt-PT': ['base', 'base'],
-  ru: ['base', 'base'],
-  es: ['nova-2-phonecall', 'nova-2'],
-  'es-419': ['nova-2-phonecall', 'nova-2'],
+  ko: ['nova-2', 'nova-2'],
+  no: ['nova-2', 'nova-2'],
+  pl: ['nova-2', 'nova-2'],
+  pt: ['nova-2', 'nova-2'],
+  'pt-BR': ['nova-2', 'nova-2'],
+  'pt-PT': ['nova-2', 'nova-2'],
+  ru: ['nova-2', 'nova-2'],
+  es: ['nova-2', 'nova-2'],
+  'es-419': ['nova-2', 'nova-2'],
   'es-LATAM': ['enhanced', 'enhanced'],
-  sv: ['enhanced', 'enhanced'],
+  sv: ['nova-2', 'nova-2'],
   ta: ['enhanced', 'enhanced'],
   taq: ['enhanced', 'enhanced'],
-  tr: ['base', 'base'],
-  uk: ['base', 'base']
+  tr: ['nova-2', 'nova-2'],
+  uk: ['nova-2', 'nova-2']
 };
 
 const selectDefaultDeepgramModel = (task, language) => {


### PR DESCRIPTION
Update the `optimalDeepramModels` based on the deepgram docs, sinc e.g nova-2-phonecall only exists for `en` and `en-US` based on the docs https://developers.deepgram.com/docs/models-languages-overview

If `phonecall` is available, use it for `gather` tasks - `nova-2` for transcription
If `nova-2` is available, use it for both
If `enhanced` is available, use it for both

nova-2-phonecall > nova-2 > enhanced