### PR TITLE
Fix issue in task say with possibly undefined this.ep

### DIFF
--- a/lib/tasks/say.js
+++ b/lib/tasks/say.js
@@ -103,7 +103,7 @@ class TaskSay extends Task {
       voice = this.options.voice_id || voice;
     }
 
-    this.ep.set({
+    ep.set({
       tts_engine: vendor,
       tts_voice: voice,
       cache_speech_handles: 1,


### PR DESCRIPTION
We have synced yesterday all services to latest 0.8.5-20 release.

Since then in the feature-server logs appeard many many error logs with 
`"message":"Cannot read properties of undefined (reading 'set')"`

I located the issue in task say `TaskSay._synthesizeWithSpecificVendor` .   When I attach the debugger I see that this.ep is sometime undefined.  So instead of this.ep we use simply the `ep` provided as argument within the function.

```
this.ep.set()  => ep.set()
```

We send first a config with silence stream, then a say task
"[say{silence_stream://750},config{set synthesizer{microsoft,en-US,en-US-AvaNeural},set recognizer{microsoft,en-GB},event notification on}]"

