### PR TITLE
fix dead lock in say verb while waiting playback-stop and say verb is…

### DIFF
--- a/lib/tasks/say.js
+++ b/lib/tasks/say.js
@@ -364,6 +364,8 @@ class TaskSay extends TtsTask {
       }
       this.ep.removeAllListeners('playback-start');
       this.ep.removeAllListeners('playback-stop');
+      // if we are waiting for playback-stop event, resolve the promise
+      if (this._playResolve) this._playResolve();
     }
   }
 


### PR DESCRIPTION
If say verb is waiting for playstop-event happens, and then new command that cause replaceApplication, the ongoing say verb will be killed, but the say.exec cannot be released due to it's still wait for playstop-callback.