### PR TITLE
fix fs keep looping forever if there is no fallback TTS

### DIFF
--- a/lib/tasks/say.js
+++ b/lib/tasks/say.js
@@ -329,10 +329,10 @@ class TaskSay extends TtsTask {
           } catch (err) {
             try {
               await startFallback(err);
+              continue;
             } catch (err) {
               this.logger.info({err}, 'Error waiting for playback-stop event');
             }
-            continue;
           } finally {
             this._playPromise = null;
             this._playResolve = null;


### PR DESCRIPTION
If tts 1st Synthesizer is failed and there is no fallback vendor, the say verb keep loopig again and again.