### PR TITLE
fix wrong vad notification to background bargin

### DIFF
--- a/lib/tasks/gather.js
+++ b/lib/tasks/gather.js
@@ -936,7 +936,10 @@ class TaskGather extends SttTask {
       if (!emptyTranscript) {
         if (this._clearTimer()) this._startTimer();
         if (this.bargein && (words + bufferedWords) >= this.minBargeinWordCount) {
-          this.logger.debug({transcript: evt.alternatives[0].transcript}, 'killing audio due to speech');
+          if (!this.playComplete) {
+            this.logger.debug({transcript: evt.alternatives[0].transcript}, 'killing audio due to speech');
+            this.emit('vad');
+          }
           this._killAudio(cs);
         }
       }

--- a/lib/tasks/gather.js
+++ b/lib/tasks/gather.js
@@ -936,10 +936,7 @@ class TaskGather extends SttTask {
       if (!emptyTranscript) {
         if (this._clearTimer()) this._startTimer();
         if (this.bargein && (words + bufferedWords) >= this.minBargeinWordCount) {
-          if (!this.playComplete) {
-            this.logger.debug({transcript: evt.alternatives[0].transcript}, 'killing audio due to speech');
-            this.emit('vad');
-          }
+          this.logger.debug({transcript: evt.alternatives[0].transcript}, 'killing audio due to speech');
           this._killAudio(cs);
         }
       }

--- a/lib/utils/background-task-manager.js
+++ b/lib/utils/background-task-manager.js
@@ -186,6 +186,8 @@ class BackgroundTaskManager extends Emitter {
   }
 
   _bargeInTaskCompleted(evt) {
+    if (!this.bargeInHandled)
+      this.bargeInHandled = true;
     this.logger.debug({evt},
       'BackgroundTaskManager:_bargeInTaskCompleted on event from background bargeIn, emitting bargein-done event');
     this.emit('bargeIn-done', evt);

--- a/lib/utils/background-task-manager.js
+++ b/lib/utils/background-task-manager.js
@@ -117,6 +117,7 @@ class BackgroundTaskManager extends Emitter {
           this._taskCompleted('bargeIn', task);
           if (task.sticky && !this.cs.callGone && !this.cs._stopping) {
             this.logger.info('BackgroundTaskManager:_initBargeIn: restarting background bargeIn');
+            this._bargeInHandled = false;
             this.newTask('bargeIn', opts, true);
           }
           return;
@@ -186,8 +187,8 @@ class BackgroundTaskManager extends Emitter {
   }
 
   _bargeInTaskCompleted(evt) {
-    if (this.bargeInHandled) return;
-    this.bargeInHandled = true;
+    if (this._bargeInHandled) return;
+    this._bargeInHandled = true;
     this.logger.debug({evt},
       'BackgroundTaskManager:_bargeInTaskCompleted on event from background bargeIn, emitting bargein-done event');
     this.emit('bargeIn-done', evt);

--- a/lib/utils/background-task-manager.js
+++ b/lib/utils/background-task-manager.js
@@ -186,8 +186,8 @@ class BackgroundTaskManager extends Emitter {
   }
 
   _bargeInTaskCompleted(evt) {
-    if (!this.bargeInHandled)
-      this.bargeInHandled = true;
+    if (this.bargeInHandled) return;
+    this.bargeInHandled = true;
     this.logger.debug({evt},
       'BackgroundTaskManager:_bargeInTaskCompleted on event from background bargeIn, emitting bargein-done event');
     this.emit('bargeIn-done', evt);


### PR DESCRIPTION
#767 

The gather fire both 2 events **vad** and **resolve** by transcription to background bargin that make bargin clean up verbs in queue twice