### PR TITLE
dtmf Barge-in disabled capturing input during prompt playing

### DIFF
--- a/lib/tasks/gather.js
+++ b/lib/tasks/gather.js
@@ -201,7 +201,7 @@ class TaskGather extends SttTask {
           this.logger.debug('Gather: nested say task completed');
           this._stopVad();
           if (!this.killed) {
-            if (this.input.includes('digits') || this.asrDtmfTerminationDigit) {
+            if ((this.input.includes('digits') && !this.dtmfBargein) || this.asrDtmfTerminationDigit) {
               ep.on('dtmf', this._onDtmf.bind(this, cs, ep));
             }
             startListening(cs, ep);
@@ -231,7 +231,7 @@ class TaskGather extends SttTask {
           this.logger.debug('Gather: nested play task completed');
           this._stopVad();
           if (!this.killed) {
-            if (this.input.includes('digits') || this.asrDtmfTerminationDigit) {
+            if ((this.input.includes('digits') && !this.dtmfBargein) || this.asrDtmfTerminationDigit) {
               ep.on('dtmf', this._onDtmf.bind(this, cs, ep));
             }
             startListening(cs, ep);

--- a/lib/tasks/gather.js
+++ b/lib/tasks/gather.js
@@ -201,6 +201,9 @@ class TaskGather extends SttTask {
           this.logger.debug('Gather: nested say task completed');
           this._stopVad();
           if (!this.killed) {
+            if (this.input.includes('digits') || this.asrDtmfTerminationDigit) {
+              ep.on('dtmf', this._onDtmf.bind(this, cs, ep));
+            }
             startListening(cs, ep);
             if (this.input.includes('speech') && this.vendor === 'nuance' && this.listenDuringPrompt) {
               this.logger.debug('Gather:exec - starting transcription timers after say completes');
@@ -228,6 +231,9 @@ class TaskGather extends SttTask {
           this.logger.debug('Gather: nested play task completed');
           this._stopVad();
           if (!this.killed) {
+            if (this.input.includes('digits') || this.asrDtmfTerminationDigit) {
+              ep.on('dtmf', this._onDtmf.bind(this, cs, ep));
+            }
             startListening(cs, ep);
             if (this.input.includes('speech') && this.vendor === 'nuance' && this.listenDuringPrompt) {
               this.logger.debug('Gather:exec - starting transcription timers after play completes');
@@ -269,7 +275,7 @@ class TaskGather extends SttTask {
         }
       }
 
-      if (this.input.includes('digits') || this.dtmfBargein || this.asrDtmfTerminationDigit) {
+      if ((this.input.includes('digits') && this.dtmfBargein) || this.asrDtmfTerminationDigit) {
         ep.on('dtmf', this._onDtmf.bind(this, cs, ep));
       }
 


### PR DESCRIPTION
If dtmfbarge-in is disable and users provide input during the playing of prompt , the input is captured , rather it should start capturing input after playing the prompt
