### PR TITLE
Added languageModelName as an aws transcribe option

### DIFF
--- a/lib/utils/transcription-utils.js
+++ b/lib/utils/transcription-utils.js
@@ -50,7 +50,8 @@ const stickyVars = {
   aws: [
     'AWS_VOCABULARY_NAME',
     'AWS_VOCABULARY_FILTER_METHOD',
-    'AWS_VOCABULARY_FILTER_NAME'
+    'AWS_VOCABULARY_FILTER_NAME',
+    'AWS_LANGUAGE_MODEL_NAME'
   ],
   nuance: [
     'NUANCE_ACCESS_TOKEN',
@@ -559,6 +560,7 @@ module.exports = (logger) => {
         ...(rOpts.vocabularyName && {AWS_VOCABULARY_NAME: rOpts.vocabularyName}),
         ...(rOpts.vocabularyFilterName && {AWS_VOCABULARY_FILTER_NAME: rOpts.vocabularyFilterName}),
         ...(rOpts.filterMethod && {AWS_VOCABULARY_FILTER_METHOD: rOpts.filterMethod}),
+        ...(rOpts.languageModelName && {AWS_LANGUAGE_MODEL_NAME: rOpts.languageModelName}),
         ...(sttCredentials && {
           ...(sttCredentials.accessKeyId && {AWS_ACCESS_KEY_ID: sttCredentials.accessKeyId}),
           ...(sttCredentials.secretAccessKey && {AWS_SECRET_ACCESS_KEY: sttCredentials.secretAccessKey}),


### PR DESCRIPTION
Currently no way to set custom language model for AWS.

This PR sets AWS_LANGUAGE_MODEL_NAME if languageModelName  is present.

Freeswitch-Modules PR
https://github.com/jambonz/freeswitch-modules/pull/99

Docs PR
https://github.com/jambonz/next-static-site/pull/94