### PR TITLE
fix: support _lccMuteStatus for conference

### DIFF
--- a/lib/tasks/conference.js
+++ b/lib/tasks/conference.js
@@ -545,6 +545,13 @@ class Conference extends Task {
   }
 
   /**
+   * mute or unmute side of the call
+   */
+  mute(callSid, doMute) {
+    this.doConferenceMute(this.callSession, {conf_mute_status: doMute});
+  }
+
+  /**
    * Add ourselves to the waitlist of sessions to be notified once
    * the conference starts
    * @param {CallSession} cs


### PR DESCRIPTION
It seems like someone forgot to implement mute for __lccMuteStatus_ operation. This PR fixes this.

https://github.com/jambonz/jambonz-feature-server/issues/854