### PR TITLE
Create Call Rest is missing target headers on outdial

### DIFF
--- a/lib/http-routes/api/create-call.js
+++ b/lib/http-routes/api/create-call.js
@@ -97,7 +97,8 @@ router.post('/',
         'X-Trace-ID': rootSpan.traceId,
         ...(req.body?.application_sid && {'X-Application-Sid': req.body.application_sid}),
         ...(restDial.fromHost && {'X-Preferred-From-Host': restDial.fromHost}),
-        ...(record_all_calls && {'X-Record-All-Calls': recordOutputFormat})
+        ...(record_all_calls && {'X-Record-All-Calls': recordOutputFormat}),
+        ...target.headers
       };
 
       switch (target.type) {


### PR DESCRIPTION
When adding customer headers to the target object on a rest dial, the headers are now present on rest dial.