### PR TITLE
Add support for configuring the IP address that is advertised to the API Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Configuration is provided via environment variables:
 |ENCRYPTION_SECRET| secret for credential encryption(JWT_SECRET is deprecated) |yes|
 |GOOGLE_APPLICATION_CREDENTIALS| path to gcp service key file|yes|
 |HTTP_PORT| tcp port to listen on for API requests from jambonz-api-server|yes|
+|HTTP_IP| IP Address for API requests from jambonz-api-server |no|
 |JAMBONES_GATHER_EARLY_HINTS_MATCH| if true and hints are provided, gather will opportunistically review interim transcripts if possible to reduce ASR latency |no|
 |JAMBONES_FREESWITCH| IP:port:secret for Freeswitch server (e.g. '127.0.0.1:8021:JambonzR0ck$'|yes|
 |JAMBONES_LOGLEVEL| log level for application, 'info' or 'debug'|no|

--- a/lib/config.js
+++ b/lib/config.js
@@ -73,6 +73,7 @@ const JAMBONES_LOGLEVEL = process.env.JAMBONES_LOGLEVEL || 'info';
 const JAMBONES_INJECT_CONTENT = process.env.JAMBONES_INJECT_CONTENT;
 
 const PORT = parseInt(process.env.HTTP_PORT, 10) || 3000;
+const HTTP_IP = process.env.HTTP_IP;
 const HTTP_PORT_MAX = parseInt(process.env.HTTP_PORT_MAX, 10);
 
 const K8S = process.env.K8S;
@@ -170,6 +171,7 @@ module.exports = {
   JAMBONES_CLUSTER_ID,
   PORT,
   HTTP_PORT_MAX,
+  HTTP_IP,
   K8S,
   K8S_SBC_SIP_SERVICE_NAME,
   JAMBONES_SUBNET,

--- a/lib/utils/install-srf-locals.js
+++ b/lib/utils/install-srf-locals.js
@@ -12,6 +12,7 @@ const {
   JAMBONES_TIME_SERIES_HOST,
   JAMBONES_ESL_LISTEN_ADDRESS,
   PORT,
+  HTTP_IP,
   NODE_ENV,
 } = require('../config');
 const Registrar = require('@jambonz/mw-registrar');
@@ -193,7 +194,8 @@ function installSrfLocals(srf, logger) {
 
   let localIp;
   try {
-    localIp = ip.address();
+    // Either use the configured IP address or call ip.address() to find it
+    localIp = HTTP_IP || ip.address();
   } catch (err) {
     logger.error({err}, 'installSrfLocals - error detecting local ipv4 address');
   }


### PR DESCRIPTION
We were running into a problem where if the feature server was running on AWS fargate ECS it would get the wrong ip address returned. The issue is the first network card in a fargate container is amazon's metadata network. The result is that the node `ip.address()` function would return that IP, instead of the IP that is on the VPC. This change allows us to override that value that is registered in redis and used by the API server to reach the feature server. 