### PR TITLE
add label to tts stt spans

### DIFF
--- a/lib/tasks/config.js
+++ b/lib/tasks/config.js
@@ -83,13 +83,13 @@ class TaskConfig extends Task {
 
     if (this.bargeIn.enable) phrase.push('enable barge-in');
     if (this.hasSynthesizer) {
-      const {vendor:v, language:l, voice} = this.synthesizer;
-      const s = `{${v},${l},${voice}}`;
+      const {vendor:v, language:l, voice, label} = this.synthesizer;
+      const s = `{${v},${l},${voice},${label || 'None'}}`;
       phrase.push(`set synthesizer${s}`);
     }
     if (this.hasRecognizer) {
-      const {vendor:v, language:l} = this.recognizer;
-      const s = `{${v},${l}}`;
+      const {vendor:v, language:l, label} = this.recognizer;
+      const s = `{${v},${l},${label || 'None'}}`;
       phrase.push(`set recognizer${s}`);
     }
     if (this.hasRecording) phrase.push(this.record.action);

--- a/lib/tasks/gather.js
+++ b/lib/tasks/gather.js
@@ -1053,6 +1053,7 @@ class TaskGather extends SttTask {
 
     this.span.setAttributes({
       channel: 1,
+      'stt.label': this.label || 'None',
       'stt.resolve': reason,
       'stt.result': JSON.stringify(evt)
     });

--- a/lib/tasks/transcribe.js
+++ b/lib/tasks/transcribe.js
@@ -463,6 +463,7 @@ class TaskTranscribe extends SttTask {
       if (this.childSpan[channel - 1] && this.childSpan[channel - 1].span) {
         this.childSpan[channel - 1].span.setAttributes({
           channel,
+          'stt.label': this.label || 'None',
           'stt.resolve': 'transcript',
           'stt.result': JSON.stringify(evt)
         });
@@ -516,7 +517,8 @@ class TaskTranscribe extends SttTask {
     if (this.childSpan[channel - 1] && this.childSpan[channel - 1].span) {
       this.childSpan[channel - 1].span.setAttributes({
         channel,
-        'stt.resolve': 'timeout'
+        'stt.resolve': 'timeout',
+        'stt.label': this.label || 'None',
       });
       this.childSpan[channel - 1].span.end();
     }
@@ -533,7 +535,8 @@ class TaskTranscribe extends SttTask {
     if (this.childSpan[channel - 1] && this.childSpan[channel - 1].span) {
       this.childSpan[channel - 1].span.setAttributes({
         channel,
-        'stt.resolve': 'max duration exceeded'
+        'stt.resolve': 'max duration exceeded',
+        'stt.label': this.label || 'None',
       });
       this.childSpan[channel - 1].span.end();
     }
@@ -617,7 +620,8 @@ class TaskTranscribe extends SttTask {
     if (this.childSpan[channel - 1] && this.childSpan[channel - 1].span) {
       this.childSpan[channel - 1].span.setAttributes({
         channel,
-        'stt.resolve': 'connection failure'
+        'stt.resolve': 'connection failure',
+        'stt.label': this.label || 'None',
       });
       this.childSpan[channel - 1].span.end();
     }

--- a/lib/tasks/tts-task.js
+++ b/lib/tasks/tts-task.js
@@ -128,7 +128,8 @@ class TtsTask extends Task {
           const {span} = this.startChildSpan('tts-generation', {
             'tts.vendor': vendor,
             'tts.language': language,
-            'tts.voice': voice
+            'tts.voice': voice,
+            'tts.label': label || 'None',
           });
           this.otelSpan = span;
         }


### PR DESCRIPTION
For a better visibility of which speech credentials have been used for TTS and STT generation, this PR is adding the label to all related spans:

- Improved by adding `tts.label` to Span `tts-generation`
- Improved by adding `stt.label` to Span `verb:gather` 
- Improved by adding stt and tts `label` to Span `verb:config - verb.summary`
- When 'None'  is selected the label should be 'None'  as well