### PR TITLE
feat/924: made actions as optional when there is no noResponseTimeout

### DIFF
--- a/lib/utils/action-hook-delay.js
+++ b/lib/utils/action-hook-delay.js
@@ -24,10 +24,12 @@ class ActionHookDelayProcessor extends Emitter {
     this._active = false;
 
     const enabled = this.init(opts);
-    if (enabled && (!this.actions || !Array.isArray(this.actions) || this.actions.length === 0)) {
+    if (enabled && this.noResponseTimeout &&
+          (!this.actions || !Array.isArray(this.actions) || this.actions.length === 0)) {
       throw new Error('ActionHookDelayProcessor: no actions specified');
     }
-    else if (enabled && this.actions.some((a) => !a.verb || ![TaskName.Say, TaskName.Play].includes(a.verb))) {
+    else if (enabled && this.actions &&
+          this.actions.some((a) => !a.verb || ![TaskName.Say, TaskName.Play].includes(a.verb))) {
       throw new Error(`ActionHookDelayProcessor: invalid actions specified: ${JSON.stringify(this.actions)}`);
     }
   }


### PR DESCRIPTION
https://github.com/jambonz/jambonz-feature-server/issues/924

Making actions property as optional when noResponseTimeout is not specified or zero, as we have introduced noResponseGiveUpTimeout and giveUpActions, the noResponseTimout & actions array can be made optional

This is an extension to the feature https://github.com/jambonz/jambonz-feature-server/issues/902
