### PR TITLE
fixed feature server kill currenttask if jambonz hangup the call

### DIFF
--- a/lib/session/inbound-call-session.js
+++ b/lib/session/inbound-call-session.js
@@ -72,6 +72,8 @@ class InboundCallSession extends CallSession {
 
   _jambonzHangup() {
     this.dlg?.destroy();
+    // kill current task or wakeup the call session.
+    this._callReleased();
   }
 
   _hangup(terminatedBy = 'jambonz') {


### PR DESCRIPTION
TO Fix issue:
Gather keep running forever if call is killed by jambonz.

TO reproduce:
1/ Have ws application return gather for deepgram vendor
2/ while gather is running, keep silence and restart ws application
3/ jambonz reconnect ws application, ws application accept the connection but don't send ack
4/ jambonz close the call
5/ gather keep running in ghost mode.