### PR TITLE
Fix the issue for outbound calls that always the None credentials wer…

### DIFF
--- a/lib/http-routes/api/create-call.js
+++ b/lib/http-routes/api/create-call.js
@@ -209,7 +209,7 @@ router.post('/',
       /**
      * create our application object -
      * we merge the inbound call application,
-     * with the the provided app params in the request body
+     * with the provided app params from the request body
      */
       const app = {
         ...application,

--- a/lib/http-routes/api/create-call.js
+++ b/lib/http-routes/api/create-call.js
@@ -208,10 +208,13 @@ router.post('/',
 
       /**
      * create our application object -
-     * not from the database as per an inbound call,
-     * but from the provided params in the request
+     * we merge the inbound call application,
+     * with the the provided app params in the request body
      */
-      const app = req.body;
+      const app = {
+        ...application,
+        ...req.body
+      };
 
       /**
      * attach our requestor and notifier objects

--- a/lib/tasks/rest_dial.js
+++ b/lib/tasks/rest_dial.js
@@ -77,11 +77,13 @@ class TaskRestDial extends Task {
           synthesizer: {
             vendor: cs.speechSynthesisVendor,
             language: cs.speechSynthesisLanguage,
-            voice: cs.speechSynthesisVoice
+            voice: cs.speechSynthesisVoice,
+            label: cs.speechSynthesisLabel,
           },
           recognizer: {
             vendor:  cs.speechRecognizerVendor,
-            language: cs.speechRecognizerLanguage
+            language: cs.speechRecognizerLanguage,
+            label: cs.speechRecognizerLabel,
           }
         }
       };


### PR DESCRIPTION

- Fix the issue for outbound calls that always the None credentials wer used. 
- session:new for rest dial did not contain `recognizer.label` and `synthesizer.label`