### PR TITLE
feat/971 - fix to allow hints objects array

### DIFF
--- a/lib/tasks/gather.js
+++ b/lib/tasks/gather.js
@@ -155,7 +155,8 @@ class TaskGather extends SttTask {
       const {hints, hintsBoost} = cs.globalSttHints;
       const setOfHints = new Set((this.data.recognizer.hints || [])
         .concat(hints)
-        .filter((h) => typeof h === 'string' && h.length > 0));
+        // allow for hints to be an array of object
+        .filter((h) => (typeof h === 'string' && h.length > 0) || (typeof h === 'object')));
       this.data.recognizer.hints = [...setOfHints];
       if (!this.data.recognizer.hintsBoost && hintsBoost) this.data.recognizer.hintsBoost = hintsBoost;
       this.logger.debug({hints: this.data.recognizer.hints, hintsBoost: this.data.recognizer.hintsBoost},


### PR DESCRIPTION
Added check to allow objects, currently the check for string type causes hints array with objects not to work