### PR TITLE
fix say verb should fallback to 2nd vendor if response_code is not 2xx

### DIFF
--- a/lib/tasks/say.js
+++ b/lib/tasks/say.js
@@ -193,8 +193,25 @@ class TaskSay extends TtsTask {
               }).catch((err) => this.logger.info({err}, 'Error adding file to cache'));
             }
 
+            function extractResponseCode(evt) {
+              for (const key in evt) {
+                if (key.startsWith('variable_tts_') && key.endsWith('_response_code')) {
+                  return evt[key];
+                }
+              }
+              return 0;
+            }
+
+            const response_code = extractResponseCode(evt);
+
             if (this._playResolve) {
-              evt.variable_tts_error ? this._playReject(new Error(evt.variable_tts_error)) : this._playResolve();
+              //if tts vendor return bad response code or there is variable_tts_error,
+              // say task should reject the promise.
+              (response_code < 200 && response_code > 299 || evt.variable_tts_error) ?
+                this._playReject(
+                  new Error(evt.variable_tts_error ||
+                    `Synthesizing error, received ${evt.variable_tts_whisper_response_code} from vendor ${vendor}`)) :
+                this._playResolve();
             }
           });
           // wait for playback-stop event received to confirm if the playback is successful

--- a/lib/tasks/say.js
+++ b/lib/tasks/say.js
@@ -207,7 +207,7 @@ class TaskSay extends TtsTask {
             if (this._playResolve) {
               //if tts vendor return bad response code or there is variable_tts_error,
               // say task should reject the promise.
-              (response_code < 200 && response_code > 299 || evt.variable_tts_error) ?
+              ((response_code < 200 && response_code > 299) || evt.variable_tts_error) ?
                 this._playReject(
                   new Error(evt.variable_tts_error ||
                     `Synthesizing error, received ${evt.variable_tts_whisper_response_code} from vendor ${vendor}`)) :


### PR DESCRIPTION
[09:18:46.199] ^[[34mDEBUG^[[39m (1001): ^[[36mSay got playback-stop^[[39m
    callId: "28be0b9d-32d2-123e-50bf-064156f7e4f7"
    callSid: "360f1cd2-9e5b-4cf5-865e-706c00bea293"
    evt: {
      "variable_tts_engine": "whisper",
      "variable_tts_voice": "alloy",
      "variable_tts_whisper_response_code": "0"
    }
    
    when we get playback-stop event with variable_tts_whisper_response_code = 0, say verb is not fallback to 2nd vendor