### PR TITLE
Make voicemail hints case insensitive

### DIFF
--- a/lib/utils/amd-utils.js
+++ b/lib/utils/amd-utils.js
@@ -153,7 +153,7 @@ class Amd extends Emitter {
       const wordCount = t.alternatives[0].transcript.split(' ').length;
       const final = t.is_final;
 
-      const foundHint = hints.find((h) =>  t.alternatives[0].transcript.includes(h));
+      const foundHint = hints.find((h) =>  t.alternatives[0].transcript.toLowerCase().includes(h.toLowerCase()));
       if (foundHint) {
         /* we detected a common voice mail greeting */
         this.logger.debug(`Amd:evaluateTranscription: found hint ${foundHint}`);


### PR DESCRIPTION
Right now the hints file search is case sensitive. Depending on the speech engine you are using things won't match. Rather than duplicating a bunch of inputs making the search case insensitive allows things to be more portable between environments. 