### PR TITLE
tts stream should save tts.response_time metric

### DIFF
--- a/lib/tasks/say.js
+++ b/lib/tasks/say.js
@@ -213,7 +213,7 @@ class TaskSay extends TtsTask {
           ep.once('playback-start', (evt) => {
             this.logger.debug({evt}, 'Say got playback-start');
             if (this.otelSpan) {
-              this._addStreamingTtsAttributes(this.otelSpan, evt);
+              this._addStreamingTtsAttributes(this.otelSpan, evt, vendor);
               this.otelSpan.end();
               this.otelSpan = null;
               if (evt.variable_tts_cache_filename) {
@@ -308,7 +308,7 @@ class TaskSay extends TtsTask {
     this.notifyTaskDone();
   }
 
-  _addStreamingTtsAttributes(span, evt) {
+  _addStreamingTtsAttributes(span, evt, vendor) {
     const attrs = {'tts.cached': false};
     for (const [key, value] of Object.entries(evt)) {
       if (key.startsWith('variable_tts_')) {
@@ -322,6 +322,9 @@ class TaskSay extends TtsTask {
           .replace('elevenlabs_', 'elevenlabs.');
         if (spanMapping[newKey]) newKey = spanMapping[newKey];
         attrs[newKey] = value;
+        if (newKey === 'final_response_ms' && value) {
+          this.cs.srf.locals.stats.histogram('tts.response_time', value, [`vendor:${vendor}`]);
+        }
       }
     }
     delete attrs['cache_filename']; //no value in adding this to the span

--- a/lib/tasks/say.js
+++ b/lib/tasks/say.js
@@ -322,7 +322,7 @@ class TaskSay extends TtsTask {
           .replace('elevenlabs_', 'elevenlabs.');
         if (spanMapping[newKey]) newKey = spanMapping[newKey];
         attrs[newKey] = value;
-        if (newKey === 'final_response_ms' && value) {
+        if (key === 'variable_tts_time_to_first_byte_ms' && value) {
           this.cs.srf.locals.stats.histogram('tts.response_time', value, [`vendor:${vendor}`]);
         }
       }


### PR DESCRIPTION
![Screenshot 2025-02-18 at 18 41 00](https://github.com/user-attachments/assets/5f513ffc-f647-4159-ba44-b368c231c04e)

https://jambonz.freshdesk.com/a/tickets/588

TTS response time is not added if HTTP tts streaming is being used