### PR TITLE
support ultravox sends createCall response to app

### DIFF
--- a/lib/tasks/llm/llms/ultravox_s2s.js
+++ b/lib/tasks/llm/llms/ultravox_s2s.js
@@ -4,6 +4,7 @@ const {request} = require('undici');
 const {LlmEvents_Ultravox} = require('../../../utils/constants');
 
 const ultravox_server_events = [
+  'createCall',
   'pong',
   'state',
   'transcript',
@@ -88,7 +89,7 @@ class TaskLlmUltravox_S2S extends Task {
       throw new Error(`Ultravox  Error registering call: ${data.message}`);
     }
     this.logger.info({joinUrl: data.joinUrl}, 'Ultravox Call registered');
-    return data.joinUrl;
+    return data;
   }
 
   _unregisterHandlers() {
@@ -105,13 +106,19 @@ class TaskLlmUltravox_S2S extends Task {
   async _startListening(cs, ep) {
     this._registerHandlers(ep);
 
-    const joinUrl = await this.createCall();
+    const data = await this.createCall();
+    const {joinUrl} = data;
     // split the joinUrl into host and path
     const {host, pathname, search} = new URL(joinUrl);
 
     try {
       const args = [ep.uuid, 'session.create', host, pathname + search];
       await this._api(ep, args);
+      // Notifiy the application that the session has been created with detail information
+      this._sendLlmEvent('createCall', {
+        type: 'createCall',
+        ...data
+      });
     } catch (err) {
       this.logger.error({err}, 'TaskLlmUltraVox_S2S:_startListening');
       this.notifyTaskDone();
@@ -190,16 +197,20 @@ class TaskLlmUltravox_S2S extends Task {
       }
     }
 
-    /* check whether we should notify on this event */
-    if (this.includeEvents.length > 0 ? this.includeEvents.includes(type) : !this.excludeEvents.includes(type)) {
-      this.parent.sendEventHook(evt)
-        .catch((err) => this.logger.info({err}, 'TaskLlmUltravox_S2S:_onServerEvent - error sending event hook'));
-    }
+    this._sendLlmEvent(type, evt);
 
     if (endConversation) {
       this.logger.info({results: this.results},
         'TaskLlmUltravox_S2S:_onServerEvent - ending conversation due to error');
       this.notifyTaskDone();
+    }
+  }
+
+  _sendLlmEvent(type, evt) {
+    /* check whether we should notify on this event */
+    if (this.includeEvents.length > 0 ? this.includeEvents.includes(type) : !this.excludeEvents.includes(type)) {
+      this.parent.sendEventHook(evt)
+        .catch((err) => this.logger.info({err}, 'TaskLlmUltravox_S2S:_onServerEvent - error sending event hook'));
     }
   }
 

--- a/lib/tasks/llm/llms/ultravox_s2s.js
+++ b/lib/tasks/llm/llms/ultravox_s2s.js
@@ -114,7 +114,7 @@ class TaskLlmUltravox_S2S extends Task {
     try {
       const args = [ep.uuid, 'session.create', host, pathname + search];
       await this._api(ep, args);
-      // Notifiy the application that the session has been created with detail information
+      // Notify the application that the session has been created with detail information
       this._sendLlmEvent('createCall', {
         type: 'createCall',
         ...data


### PR DESCRIPTION
jambonz use ultravox createCall REST API to get joinURL for making s2s connection. the createCall response contains callId that allow apps can keep track ultravox session.

This PR is for sending createCall response Data to the app.