### PR TITLE
if redirect to new server update requestor for baseURL

### DIFF
--- a/lib/tasks/redirect.js
+++ b/lib/tasks/redirect.js
@@ -1,6 +1,8 @@
 const Task = require('./task');
 const {TaskName} = require('../utils/constants');
 const WsRequestor = require('../utils/ws-requestor');
+const URL = require('url');
+const HttpRequestor = require('../utils/http-requestor');
 
 /**
  * Redirects to a new application
@@ -23,6 +25,21 @@ class TaskRedirect extends Task {
         this.cs.application.requestor = requestor;
       } catch (err) {
         this.logger.info(err, `Task:performAction error redirecting to ${this.actionHook}`);
+      }
+    } else if (cs.application.requestor._isAbsoluteUrl(this.actionHook)) {
+      const baseUrl =  this.cs.application.requestor.baseUrl;
+      const newUrl = URL.parse(this.actionHook);
+      const newBaseUrl = newUrl.protocol + '//' + newUrl.host;
+      if (baseUrl != newBaseUrl) {
+        try {
+          this.logger.info(`Task:redirect updating base url to ${newBaseUrl}`);
+          const newRequestor = new HttpRequestor(this.logger, cs.accountSid, {url: this.actionHook},
+            cs.accountInfo.account.webhook_secret);
+          this.cs.requestor.removeAllListeners();
+          this.cs.application.requestor = newRequestor;
+        } catch (err) {
+          this.logger.info(err, `Task:redirect error updating base url to ${this.actionHook}`);
+        }
       }
     }
     await this.performAction();


### PR DESCRIPTION
fixes #1079 

This doesn't update the notifier object so the call status webhooks will still go to the original app url, but where the callHook is updated any future relative URLs in the new app will goto that server.