### PR TITLE
ws requestor  should store initial sessionData when sending session:adulting

### DIFF
--- a/lib/utils/ws-requestor.js
+++ b/lib/utils/ws-requestor.js
@@ -133,7 +133,7 @@ class WsRequestor extends BaseRequestor {
 
     /* prepare and send message */
     let payload = params ? snakeCaseKeys(params, ['customerData', 'sip']) : null;
-    if (type === 'session:new') this._sessionData = payload;
+    if (type === 'session:new' || type === 'session:adulting') this._sessionData = payload;
     if (type === 'session:reconnect') payload = this._sessionData;
     assert.ok(url, 'WsRequestor:request url was not provided');
 


### PR DESCRIPTION
When session:aduting happen, new ws requestor object will be created without session:new command.
ws requestor have to store initial session data when session:adulting is sent
https://jambonz.freshdesk.com/a/tickets/647