### PR TITLE
Feature: add digitCount to amd-utils

### DIFF
--- a/lib/utils/amd-utils.js
+++ b/lib/utils/amd-utils.js
@@ -45,6 +45,7 @@ if (VMD_HINTS_FILE) {
   });
 }
 
+
 class Amd extends Emitter {
   constructor(logger, cs, opts) {
     super();
@@ -68,6 +69,8 @@ class Amd extends Emitter {
     this.getIbmAccessToken = getIbmAccessToken;
     const {setChannelVarsForStt} = require('./transcription-utils')(logger);
     this.setChannelVarsForStt = setChannelVarsForStt;
+    this.digitCount = opts.digitCount || 0;
+    this.numberRegEx = RegExp(`[0-9]{${this.digitCount}}`)
 
     const {
       noSpeechTimeoutMs = 5000,
@@ -160,6 +163,14 @@ class Amd extends Emitter {
         this.emit(this.decision = AmdEvents.MachineDetected, {
           reason: 'hint',
           hint: foundHint,
+          language: t.language_code
+        });
+      }
+      else if (this.digitCount != 0 && this.numberRegEx.test(t.alternatives[0].transcript)){
+        /* a string of numbers is typically a machine */
+        this.emit(this.decision = AmdEvents.MachineDetected, {
+          reason: 'digit count',
+          greeting: t.alternatives[0].transcript,
           language: t.language_code
         });
       }

--- a/lib/utils/amd-utils.js
+++ b/lib/utils/amd-utils.js
@@ -70,7 +70,7 @@ class Amd extends Emitter {
     const {setChannelVarsForStt} = require('./transcription-utils')(logger);
     this.setChannelVarsForStt = setChannelVarsForStt;
     this.digitCount = opts.digitCount || 0;
-    this.numberRegEx = RegExp(`[0-9]{${this.digitCount}}`)
+    this.numberRegEx = RegExp(`[0-9]{${this.digitCount}}`);
 
     const {
       noSpeechTimeoutMs = 5000,
@@ -166,7 +166,7 @@ class Amd extends Emitter {
           language: t.language_code
         });
       }
-      else if (this.digitCount != 0 && this.numberRegEx.test(t.alternatives[0].transcript)){
+      else if (this.digitCount != 0 && this.numberRegEx.test(t.alternatives[0].transcript)) {
         /* a string of numbers is typically a machine */
         this.emit(this.decision = AmdEvents.MachineDetected, {
           reason: 'digit count',

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@jambonz/speech-utils": "^0.2.3",
         "@jambonz/stats-collector": "^0.1.10",
         "@jambonz/time-series": "^0.2.13",
-        "@jambonz/verb-specifications": "^0.0.97",
+        "@jambonz/verb-specifications": "^0.0.98",
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/exporter-jaeger": "^1.23.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.50.0",
@@ -1550,9 +1550,9 @@
       }
     },
     "node_modules/@jambonz/verb-specifications": {
-      "version": "0.0.97",
-      "resolved": "https://registry.npmjs.org/@jambonz/verb-specifications/-/verb-specifications-0.0.97.tgz",
-      "integrity": "sha512-CncykmCwc8YZcDYwFDq88n6IAyoQNae3lSF2BI5etoBKMujzxOty227lq6zgeXun9UYYDy/CONk5MiLO29kcBg==",
+      "version": "0.0.98",
+      "resolved": "https://registry.npmjs.org/@jambonz/verb-specifications/-/verb-specifications-0.0.98.tgz",
+      "integrity": "sha512-G55q5JGtbdowj+hBVBlApBsMBwG4rneJqUc1jcp/IksrlPlUjxMZURXi6jxmg87lZSX/u88osoG2olXnFhYU3g==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -3647,9 +3647,10 @@
       }
     },
     "node_modules/drachtio-srf": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/drachtio-srf/-/drachtio-srf-5.0.2.tgz",
-      "integrity": "sha512-tM4TVNoC3IpdmpNn2gnuIp5AzNF6Ik6rvRTFjmQ25/W4gb4eVzK8cCYntc00rtbENI4HHmrX4Ep+/T+ZVnoTDw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/drachtio-srf/-/drachtio-srf-5.0.3.tgz",
+      "integrity": "sha512-gOeOmU3LsrDXAw8a9Vd+od6cJXyqqV5E+2LsCD2N1SjoJybJS72PHTN+GfKtk3fRhFYpww2325CO4pr/DK21cA==",
+      "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7",
         "delegates": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@jambonz/realtimedb-helpers": "^0.8.8",
     "@jambonz/speech-utils": "^0.2.3",
     "@jambonz/stats-collector": "^0.1.10",
-    "@jambonz/verb-specifications": "^0.0.97",
+    "@jambonz/verb-specifications": "^0.0.98",
     "@jambonz/time-series": "^0.2.13",
     "@opentelemetry/api": "^1.8.0",
     "@opentelemetry/exporter-jaeger": "^1.23.0",


### PR DESCRIPTION
Adds a new feature to AMD,

Many voicemail systems (especially on cellular) include the called number as part of their default greeting, the transcription engines return these digits as a single "word" eg `07790123900 is not availble` rather than spacing out each digit as a new word, therefore the `thresholdWordCount` is often not reached for what is in effect a long message.

This adds a new feature that allows you to set a `digitCount` property on the AMD check and if there is a string of digits detected it will trigger on that.
By default it is off (digitCount = 0) so won't trigger. 
The length is adjustable for different scenarios and counties, with UK numbers I've found that 5-6 is a good value.

There are _some_ older people in the UK at least that still answer their landlines with the phone number eg "London 1234" so like all AMD this won't be rock solid but I think its a useful addition.

There's a corresponding PR in verb-specifications too (https://github.com/jambonz/verb-specifications/pull/88) and if we decide to go with it, and I'll PR the docs when merged