### PR TITLE
use deepgramOptions.model

### DIFF
--- a/lib/utils/transcription-utils.js
+++ b/lib/utils/transcription-utils.js
@@ -789,7 +789,7 @@ module.exports = (logger) => {
       };
     }
     else if ('deepgram' === vendor) {
-      let {model} = rOpts;
+      let model = rOpts.deepgramOptions.model || rOpts.model
       const {deepgramOptions = {}} = rOpts;
       const deepgramUri = deepgramOptions.deepgramSttUri || sttCredentials.deepgram_stt_uri;
       const useTls = deepgramOptions.deepgramSttUseTls || sttCredentials.deepgram_stt_use_tls;

--- a/lib/utils/transcription-utils.js
+++ b/lib/utils/transcription-utils.js
@@ -789,7 +789,7 @@ module.exports = (logger) => {
       };
     }
     else if ('deepgram' === vendor) {
-      let model = rOpts.deepgramOptions.model || rOpts.model;
+      let model = rOpts.deepgramOptions?.model || rOpts.model;
       const {deepgramOptions = {}} = rOpts;
       const deepgramUri = deepgramOptions.deepgramSttUri || sttCredentials.deepgram_stt_uri;
       const useTls = deepgramOptions.deepgramSttUseTls || sttCredentials.deepgram_stt_use_tls;

--- a/lib/utils/transcription-utils.js
+++ b/lib/utils/transcription-utils.js
@@ -789,7 +789,7 @@ module.exports = (logger) => {
       };
     }
     else if ('deepgram' === vendor) {
-      let model = rOpts.deepgramOptions.model || rOpts.model
+      let model = rOpts.deepgramOptions.model || rOpts.model;
       const {deepgramOptions = {}} = rOpts;
       const deepgramUri = deepgramOptions.deepgramSttUri || sttCredentials.deepgram_stt_uri;
       const useTls = deepgramOptions.deepgramSttUseTls || sttCredentials.deepgram_stt_use_tls;


### PR DESCRIPTION
This uses the value of deepgramOptions.model in the recognizer as per the docs,
It will still fallback to using recognizer.model if that is set but the deepgramOptions will take priortiy if both are set as that feels like a more specific setting but doesn't break any existing apps.