### PR TITLE
return default empty conversation_initiation_client_data message

### DIFF
--- a/lib/tasks/llm/llms/elevenlabs_s2s.js
+++ b/lib/tasks/llm/llms/elevenlabs_s2s.js
@@ -49,7 +49,7 @@ class TaskLlmElevenlabs_S2S extends Task {
       input_sample_rate = 16000,
       output_sample_rate = 16000
     } = this.data.llmOptions;
-    this.conversation_initiation_client_data = conversation_initiation_client_data;
+    this.conversation_initiation_client_data = conversation_initiation_client_data || {};
     this.input_sample_rate = input_sample_rate;
     this.output_sample_rate = output_sample_rate;
     this.results = {
@@ -186,14 +186,14 @@ class TaskLlmElevenlabs_S2S extends Task {
   }
 
   async _sendInitialMessage(ep) {
-    if (this.conversation_initiation_client_data) {
+    //if (this.conversation_initiation_client_data) {
       if (!await this._sendClientEvent(ep, {
         type: 'conversation_initiation_client_data',
         ...this.conversation_initiation_client_data
       })) {
         this.notifyTaskDone();
       }
-    }
+    //}
   }
 
   _registerHandlers(ep) {

--- a/lib/tasks/llm/llms/elevenlabs_s2s.js
+++ b/lib/tasks/llm/llms/elevenlabs_s2s.js
@@ -186,14 +186,12 @@ class TaskLlmElevenlabs_S2S extends Task {
   }
 
   async _sendInitialMessage(ep) {
-    //if (this.conversation_initiation_client_data) {
-      if (!await this._sendClientEvent(ep, {
-        type: 'conversation_initiation_client_data',
-        ...this.conversation_initiation_client_data
-      })) {
-        this.notifyTaskDone();
-      }
-    //}
+    if (!await this._sendClientEvent(ep, {
+      type: 'conversation_initiation_client_data',
+      ...this.conversation_initiation_client_data
+    })) {
+      this.notifyTaskDone();
+    }
   }
 
   _registerHandlers(ep) {


### PR DESCRIPTION
This will send an initiation message with just the type field if no options have been specified by the user which will then allow the freeswitch module to start sending audio.
You can see that the message is sent in the freeswitch log:
`2025-04-11 13:28:02.427817 89.73% [DEBUG] elevenlabs_glue.cpp:369 elevenlabs_s2s_send_client_event: {"type":"conversation_initiation_client_data"}`

Tested with both conversation_initiation_client_data data and with just the sampleRate in llmOptions