### PR TITLE
ensure that all actions play at least once

### DIFF
--- a/lib/utils/action-hook-delay.js
+++ b/lib/utils/action-hook-delay.js
@@ -51,7 +51,7 @@ class ActionHookDelayProcessor extends Emitter {
     this.logger.debug({opts}, 'ActionHookDelayProcessor#init');
 
     this.actions = opts.actions;
-    this.retries = opts.retries || 0;
+    this.retries = Math.max((opts.retries || 1), opts.actions.length);
     this.noResponseTimeout = opts.noResponseTimeout;
     this.noResponseGiveUpTimeout = opts.noResponseGiveUpTimeout;
     this.giveUpActions = opts.giveUpActions;


### PR DESCRIPTION
fixes #1155 

This is a non-breaking change to the API in that the experience when retries is greater than the number of actions is the same but for the scenario where a user has specified multiple actions but not set retries (or set to 1) it will still play each action once (unless the actionHook responds before then)

Will also update docs for the retries param to clarify the expereince