### PR TITLE
urlencode the . in a url querystring on play

### DIFF
--- a/lib/tasks/play.js
+++ b/lib/tasks/play.js
@@ -6,7 +6,7 @@ class TaskPlay extends Task {
     super(logger, opts);
     this.preconditions = TaskPreconditions.Endpoint;
 
-    this.url = this.data.url;
+    this.url = this.data.url.split('?')[0]+'?'+this.data.url.split("?")[1].replaceAll('.', '%2E');
     this.seekOffset = this.data.seekOffset || -1;
     this.timeoutSecs = this.data.timeoutSecs || -1;
     this.loop = this.data.loop || 1;

--- a/lib/tasks/play.js
+++ b/lib/tasks/play.js
@@ -6,9 +6,9 @@ class TaskPlay extends Task {
     super(logger, opts);
     this.preconditions = TaskPreconditions.Endpoint;
 
-    this.url = this.data.url.includes('?') 
-    ? this.data.url.split('?')[0] + '?' + this.data.url.split('?')[1].replaceAll('.', '%2E')
-    : this.data.url;
+    this.url = this.data.url.includes('?')
+      ? this.data.url.split('?')[0] + '?' + this.data.url.split('?')[1].replaceAll('.', '%2E')
+      : this.data.url;
     this.seekOffset = this.data.seekOffset || -1;
     this.timeoutSecs = this.data.timeoutSecs || -1;
     this.loop = this.data.loop || 1;

--- a/lib/tasks/play.js
+++ b/lib/tasks/play.js
@@ -6,7 +6,9 @@ class TaskPlay extends Task {
     super(logger, opts);
     this.preconditions = TaskPreconditions.Endpoint;
 
-    this.url = this.data.url.split('?')[0] + '?' + this.data.url.split('?')[1].replaceAll('.', '%2E');
+    this.url = this.data.url.includes('?') 
+    ? this.data.url.split('?')[0] + '?' + this.data.url.split('?')[1].replaceAll('.', '%2E')
+    : this.data.url;
     this.seekOffset = this.data.seekOffset || -1;
     this.timeoutSecs = this.data.timeoutSecs || -1;
     this.loop = this.data.loop || 1;

--- a/lib/tasks/play.js
+++ b/lib/tasks/play.js
@@ -6,7 +6,7 @@ class TaskPlay extends Task {
     super(logger, opts);
     this.preconditions = TaskPreconditions.Endpoint;
 
-    this.url = this.data.url.split('?')[0]+'?'+this.data.url.split("?")[1].replaceAll('.', '%2E');
+    this.url = this.data.url.split('?')[0] + '?' + this.data.url.split('?')[1].replaceAll('.', '%2E');
     this.seekOffset = this.data.seekOffset || -1;
     this.timeoutSecs = this.data.timeoutSecs || -1;
     this.loop = this.data.loop || 1;


### PR DESCRIPTION
This is a fix for a long standing freeswitch bug relating to mod_http_cache and playback.

Where a url has a query string and that query string contains a period (which is a valid character) freeswitch fails to properly cache the file as it looks for the last . in the url and splits that off to determine the file type eg .mp3 or .wav

This fix urlencodes any period chars on int the query string to `%2E` which is still a valid value for the webserver that returns the media as it will decode that on input. 

But this allows freeswitch to now cache and playback the file normally.