### PR TITLE
use tmpFiles list of parent call-session

### DIFF
--- a/lib/session/confirm-call-session.js
+++ b/lib/session/confirm-call-session.js
@@ -8,7 +8,8 @@ const CallSession = require('./call-session');
 
  */
 class ConfirmCallSession extends CallSession {
-  constructor({logger, application, dlg, ep, tasks, callInfo, accountInfo, memberId, confName, rootSpan, req}) {
+  // eslint-disable-next-line max-len
+  constructor({logger, application, dlg, ep, tasks, callInfo, accountInfo, memberId, confName, rootSpan, req, tmpFiles}) {
     super({
       logger,
       application,
@@ -24,6 +25,7 @@ class ConfirmCallSession extends CallSession {
     this.dlg = dlg;
     this.ep = ep;
     this.req = req;
+    this.tmpFiles = tmpFiles;
   }
 
   /**

--- a/lib/tasks/conference.js
+++ b/lib/tasks/conference.js
@@ -673,7 +673,8 @@ class Conference extends Task {
         confName: this.confName,
         tasks,
         rootSpan: cs.rootSpan,
-        req: cs.req
+        req: cs.req,
+        tmpFiles: cs.tmpFiles,
       });
       await this._playSession.exec();
       this._playSession = null;

--- a/lib/tasks/dial.js
+++ b/lib/tasks/dial.js
@@ -1098,7 +1098,8 @@ class TaskDial extends Task {
               accountInfo: this.cs.accountInfo,
               tasks,
               rootSpan: this.cs.rootSpan,
-              req: this.cs.req
+              req: this.cs.req,
+              tmpFiles: this.cs.tmpFiles,
             });
             await this._onHoldSession.exec();
             this._onHoldSession = null;

--- a/lib/tasks/enqueue.js
+++ b/lib/tasks/enqueue.js
@@ -370,7 +370,8 @@ class TaskEnqueue extends Task {
         accountInfo: cs.accountInfo,
         tasks: tasksToRun,
         rootSpan: cs.rootSpan,
-        req: cs.req
+        req: cs.req,
+        tmpFiles: cs.tmpFiles,
       });
       await this._playSession.exec();
       this._playSession = null;

--- a/lib/utils/place-outdial.js
+++ b/lib/utils/place-outdial.js
@@ -401,7 +401,8 @@ class SingleDialer extends Emitter {
         accountInfo: this.accountInfo,
         tasks,
         rootSpan: this.rootSpan,
-        req: this.req
+        req: this.req,
+        tmpFiles: cs.tmpFiles,
       });
       await cs.exec();
 


### PR DESCRIPTION
The ConfirmCallSession will now use the tmpFiles set of the parent CallSession to store the references to the files created, this means that when the call ends these files are cleaned up by the CallSession _clearRescources funciton

fixes #1299