### PR TITLE
fix assert, and force methods to upper case

### DIFF
--- a/lib/utils/http-requestor.js
+++ b/lib/utils/http-requestor.js
@@ -41,7 +41,7 @@ class HttpRequestor extends BaseRequestor {
   constructor(logger, account_sid, hook, secret) {
     super(logger, account_sid, hook, secret);
 
-    this.method = hook.method || 'POST';
+    this.method = hook.method.toUpperCase() || 'POST';
     this.authHeader = basicAuth(hook.username, hook.password);
     this.backoffMs = 500;
 
@@ -111,7 +111,7 @@ class HttpRequestor extends BaseRequestor {
 
     const payload = params ? snakeCaseKeys(params, ['customerData', 'sip', 'env_vars', 'args']) : null;
     const url = hook.url || hook;
-    const method = hook.method || 'POST';
+    const method = hook.method.toUpperCase() || 'POST';
     let buf = '';
     httpHeaders = {
       ...httpHeaders,
@@ -119,7 +119,7 @@ class HttpRequestor extends BaseRequestor {
     };
 
     assert.ok(url, 'HttpRequestor:request url was not provided');
-    assert.ok, (['GET', 'POST'].includes(method), `HttpRequestor:request method must be 'GET' or 'POST' not ${method}`);
+    assert.ok(['GET', 'POST'].includes(method), `HttpRequestor:request method must be 'GET' or 'POST' not ${method}`);
     const startAt = process.hrtime();
 
     /* if we have an absolute url, and it is ws then do a websocket connection */


### PR DESCRIPTION
Fixes a bug where the assertat L122 was not having any effect therefore invalid methods were being actioned to the callHook url resulting in 400 errors being returned.

Also added function to set the hook.method to uppercase so if the user enters `post` it will still work and not require them to enter `POST` 