### PR TITLE
pass recogniser opts in amd to stt

### DIFF
--- a/lib/utils/amd-utils.js
+++ b/lib/utils/amd-utils.js
@@ -281,13 +281,17 @@ module.exports = (logger) => {
 
     /* set stt options */
     logger.info(`starting amd for vendor ${vendor} and language ${language}`);
-    const sttOpts = amd.setChannelVarsForStt({name: TaskName.Gather}, sttCredentials, language, {
-      vendor,
-      hints,
-      enhancedModel: true,
-      altLanguages: opts.recognizer?.altLanguages || [],
-      initialSpeechTimeoutMs: opts.resolveTimeoutMs,
-    });
+    /* if opts contains recognizer object use that config for stt, otherwise use defaults */
+    const rOpts = opts.recognizer ?
+      opts.recognizer :
+      {
+        vendor,
+        hints,
+        enhancedModel: true,
+        altLanguages: opts.recognizer?.altLanguages || [],
+        initialSpeechTimeoutMs: opts.resolveTimeoutMs,
+      };
+    const sttOpts = amd.setChannelVarsForStt({name: TaskName.Gather}, sttCredentials, language, rOpts);
 
     await ep.set(sttOpts).catch((err) => logger.info(err, 'Error setting channel variables'));
 


### PR DESCRIPTION
This now passes through any options on the recogniser object in an AMD verb to the transcription request.

For example setting a custom model as show here is now passed to deepgram (my account didn't have the model hence the 403) 
<img width="1081" height="438" alt="image" src="https://github.com/user-attachments/assets/c636fe7d-01b9-47cc-810d-607b9e71e1e8" />

