### PR TITLE
Feat/freeswitch logging

### DIFF
--- a/lib/session/call-session.js
+++ b/lib/session/call-session.js
@@ -2378,6 +2378,7 @@ Duration=${duration} `
       const ep = await this._createMediaEndpoint({
         headers: {
           'X-Jambones-Call-ID': this.callId,
+          'X-Call-Sid': this.callSid,
         },
         remoteSdp: this.req.body
       });

--- a/lib/utils/stt-latency-calculator.js
+++ b/lib/utils/stt-latency-calculator.js
@@ -101,8 +101,6 @@ class SttLatencyCalculator extends Emitter {
       }
       this.isRunning = false;
       this.logger.info('STT Latency Calculator stopped');
-    } else {
-      this.logger.warn('Latency calculator is not running, no VAD detection to stop');
     }
   }
 
@@ -116,7 +114,7 @@ class SttLatencyCalculator extends Emitter {
       return;
     }
     this._startVad();
-    this.logger.info('STT Latency Calculator started');
+    this.logger.debug('STT Latency Calculator started');
   }
 
   stop() {


### PR DESCRIPTION
pass the jambonz call_sid to freeswitch so that we can add it to freeswitch logging for better correlation of freeswitch logs to feature server logs