### PR TITLE
No need to re-anchor if env var for always anchor set

### DIFF
--- a/lib/session/call-session.js
+++ b/lib/session/call-session.js
@@ -27,6 +27,7 @@ const TtsStreamingBuffer = require('../utils/tts-streaming-buffer');
 const StickyEventEmitter = require('../utils/sticky-event-emitter');
 const {parseUri} = require('drachtio-srf');
 const {
+  ANCHOR_MEDIA_ALWAYS,
   JAMBONES_INJECT_CONTENT,
   JAMBONES_EAGERLY_PRE_CACHE_AUDIO,
   AWS_REGION,
@@ -2612,8 +2613,10 @@ Duration=${duration} `
       tidyUp();
     }
     else {
-      this.logger.debug('CallSession:propagateAnswer - call already answered - re-anchor media with a reinvite');
-      await this.dlg.modify(this.ep.local.sdp);
+      if (!ANCHOR_MEDIA_ALWAYS) {
+        this.logger.debug('CallSession:propagateAnswer - call already answered - re-anchor media with a reinvite');
+        await this.dlg.modify(this.ep.local.sdp);
+      }
     }
   }
 


### PR DESCRIPTION
If we have the env var set for always anchor media set, theres no need to do a re-invite in the scenario where the call has already been answered.

In my effort to get Jambonz working with Whatsapp Business Calling, this was causing a reinvite to be sent to the Meta servers - which for whatever reason, they don't like. The SDP didn't change at all in the reinvite coming out of freeswitch. That led me to finding the log line about the call already being answered and to re-anchor. But, I'd already set the ENV var to say always anchor - so the extra re-invite isn't needed.

Separately I'm trying to work out what Whatsapp didn't like about the reinvite so that we can just fix that too.

This is against main - I'd like to backport it to 0.9.4-4 once this is merged.

I've tested it and it works. I'd like opinions on whether this is the right move.