### PR TITLE
Fix for unable to use mod_aws_transribe post v0.9.1 version

### DIFF
--- a/lib/utils/transcription-utils.js
+++ b/lib/utils/transcription-utils.js
@@ -785,12 +785,15 @@ module.exports = (logger) => {
           AWS_ACCESS_KEY_ID: sttCredentials.accessKeyId,
           AWS_SECRET_ACCESS_KEY: sttCredentials.secretAccessKey,
           AWS_REGION: sttCredentials.region,
-          AWS_SECURITY_TOKEN: sttCredentials.securityToken
+          AWS_SECURITY_TOKEN: sttCredentials.securityToken,
+          AWS_SESSION_TOKEN: sttCredentials.sessionToken ? sttCredentials.sessionToken : sttCredentials.securityToken
         }),
         ...(awsOptions.accessKey && {AWS_ACCESS_KEY_ID: awsOptions.accessKey}),
         ...(awsOptions.secretKey && {AWS_SECRET_ACCESS_KEY: awsOptions.secretKey}),
         ...(awsOptions.region && {AWS_REGION: awsOptions.region}),
         ...(awsOptions.securityToken && {AWS_SECURITY_TOKEN: awsOptions.securityToken}),
+        ...(awsOptions.sessionToken && {AWS_SESSION_TOKEN: awsOptions.sessionToken ?
+          awsOptions.sessionToken : awsOptions.securityToken}),
         ...(awsOptions.languageModelName && {AWS_LANGUAGE_MODEL_NAME: awsOptions.languageModelName}),
         ...(awsOptions.piiEntityTypes?.length && {AWS_PII_ENTITY_TYPES: awsOptions.piiEntityTypes.join(',')}),
         ...(awsOptions.piiIdentifyEntities && {AWS_PII_IDENTIFY_ENTITIES: true}),


### PR DESCRIPTION

Unable to use mod_aws_transcribe module due to security error as sessionId is not populated