### PR TITLE
Updated the behaviour of timeout and interDigitTimeout handling

### DIFF
--- a/lib/tasks/gather.js
+++ b/lib/tasks/gather.js
@@ -43,9 +43,14 @@ class TaskGather extends SttTask {
     if (!this.input) {
       this.input = ['digits'];
     }
-    /* when collecting dtmf, bargein on dtmf is true unless explicitly set to false */
-    if (this.dtmfBargein !== false  && this.input.includes('digits')) this.dtmfBargein = true;
-
+    if (this.input.includes('digits')) {
+        /* when collecting dtmf, bargein on dtmf is true unless explicitly set to false */
+        if (this.dtmfBargein !== false)
+            this.dtmfBargein = true;
+        /* default interDigitTimeout to 3 seconds if not specified */
+        if (this.interDigitTimeout === undefined)
+            this.interDigitTimeout = 3;
+    }
     /* timeout of zero means no timeout */
     this.timeout = this.timeout === 0 ? 0 : (this.timeout || 15) * 1000;
     this.interim = !!this.partialResultHook || this.bargein || (this.timeout > 0);
@@ -368,10 +373,14 @@ class TaskGather extends SttTask {
 
   _onDtmf(cs, ep, evt) {
     this.logger.debug(evt, 'TaskGather:_onDtmf');
-    if (!this._timeoutTimer && this.timeout > 0) {
+    clearTimeout(this.interDigitTimer);
+    if (this.input.includes('digits')) {
+      /* interdigit timeout takes over */
+      if (this.digitBuffer.length === 0)
+        this._clearTimer();
+    } else if (!this._timeoutTimer && this.timeout > 0) {
       this._startTimer();
     }
-    clearTimeout(this.interDigitTimer);
     let resolved = false;
     if (this.dtmfBargein) {
       if (!this.playComplete) {
@@ -389,7 +398,8 @@ class TaskGather extends SttTask {
     }
     if (evt.dtmf === this.finishOnKey && this.input.includes('digits')) {
       resolved = true;
-      this._resolve('dtmf-terminator-key');
+      // validate the input. timeout resolution is not quite right here
+      this._resolve(this.digitBuffer.length >= this.minDigits ? 'dtmf-terminator-key' : 'timeout');
     }
     else if (this.input.includes('digits')) {
       if (this.digitBuffer.length === 0 && this.needsStt) {
@@ -404,11 +414,16 @@ class TaskGather extends SttTask {
         this._resolve('dtmf-num-digits');
       }
     }
-    if (!resolved && this.interDigitTimeout > 0 && this.digitBuffer.length >= this.minDigits) {
+    if (!resolved && this.interDigitTimeout > 0) {
       /* start interDigitTimer */
       const ms = this.interDigitTimeout * 1000;
       this.logger.debug(`starting interdigit timer of ${ms}`);
-      this.interDigitTimer = setTimeout(() => this._resolve('dtmf-interdigit-timeout'), ms);
+      this.interDigitTimer = setTimeout(
+        () => {
+          if (this.isContinuousAsr) this._startAsrTimer();
+          this._resolve(this.digitBuffer.length >= this.minDigits ? 'dtmf-num-digits' : 'timeout');
+        }, ms
+      );
     }
   }
 
@@ -703,10 +718,11 @@ class TaskGather extends SttTask {
     this._clearTimer();
     this._timeoutTimer = setTimeout(() => {
       if (this.isContinuousAsr) this._startAsrTimer();
-      if (this.interDigitTimer) return; // let the inter-digit timer complete
-      else {
-        this._resolve(this.digitBuffer.length >= this.minDigits ? 'dtmf-num-digits' : 'timeout');
-      }
+      // We can be here only if this.dtmfBargein || this.asrDtmfTerminationDigit
+      // We are not collecting DTMF input according to minDigits requremets,
+      // as that is for user input via gather
+      // Should we do this._resolve('timeout'); instead of
+      this._resolve(this.digitBuffer.length >= this.minDigits ? 'dtmf-num-digits' : 'timeout');
     }, this.timeout);
   }
 


### PR DESCRIPTION
I aligned the behaviour with the VXML specification, which reflects industry practice.

The VXML 2.0 standard: https://www.w3.org/TR/voicexml20/
Appendix D — Timing Properties
D.1. DTMF Grammars
The "grammar" here is the rules defined by minDigits , maxDigits and numDigits.
The only difference is that there is no separate termtimeout parameter. The code uses interDigitTimeout as interdigittimeout and termtimeout.

The current implementation:
- keeps using timeout until minDigits reached
- can return an invalid input where the number of digits is less than minDigits
