### PR TITLE
Fix a crash in BackgroundTaskManager when background task initialization races with early call termination

### DIFF
--- a/lib/utils/background-task-manager.js
+++ b/lib/utils/background-task-manager.js
@@ -52,7 +52,7 @@ class BackgroundTaskManager extends Emitter {
       default:
         break;
     }
-    if (task) {
+    if (task && task.span) {
       this.tasks.set(type, task);
     }
     if (task && sticky) task.sticky = true;
@@ -64,7 +64,7 @@ class BackgroundTaskManager extends Emitter {
     if (task) {
       this.logger.info(`stopping background task: ${type}`);
       task.removeAllListeners();
-      task.span.end();
+      if (task.span && typeof task.span.end === 'function') task.span.end();
       task.kill(this.cs);
       // Remove task from managed List
       this.tasks.delete(type);
@@ -95,6 +95,7 @@ class BackgroundTaskManager extends Emitter {
         .catch(this._taskError.bind(this, type, task));
     } catch (err) {
       this.logger.info({err, opts}, `BackgroundTaskManager:_initListen - Error creating ${bugname} task`);
+      return undefined;
     }
     return task;
   }
@@ -129,6 +130,7 @@ class BackgroundTaskManager extends Emitter {
         .catch(this._taskError.bind(this, 'bargeIn', task));
     } catch (err) {
       this.logger.info(err, 'BackgroundTaskManager:_initGather - Error creating bargeIn task');
+      return undefined;
     }
     return task;
   }
@@ -173,6 +175,7 @@ class BackgroundTaskManager extends Emitter {
         .catch(this._taskError.bind(this, 'transcribe', task));
     } catch (err) {
       this.logger.info(err, 'BackgroundTaskManager:_initTranscribe - Error creating transcribe task');
+      return undefined;
     }
     return task;
   }
@@ -192,6 +195,7 @@ class BackgroundTaskManager extends Emitter {
         .catch(this._taskError.bind(this, 'ttsStream', task));
     } catch (err) {
       this.logger.info(err, 'BackgroundTaskManager:_initTtsStream - Error creating ttsStream task');
+      return undefined;
     }
     return task;
   }
@@ -199,13 +203,13 @@ class BackgroundTaskManager extends Emitter {
   _taskCompleted(type, task) {
     this.logger.debug({type, task}, `BackgroundTaskManager:_taskCompleted: task completed, sticky: ${task.sticky}`);
     task.removeAllListeners();
-    task.span.end();
+    if (task.span && typeof task.span.end === 'function') task.span.end();
     this.tasks.delete(type);
   }
   _taskError(type, task, error) {
     this.logger.info({type, task, error}, 'BackgroundTaskManager:_taskError: task Error');
     task.removeAllListeners();
-    task.span.end();
+    if (task.span && typeof task.span.end === 'function') task.span.end();
     this.tasks.delete(type);
   }
 


### PR DESCRIPTION

- Summary
  - Fix a crash in `BackgroundTaskManager` when background task initialization races with early call termination (e.g., quick CANCEL). Add defensive guards and ensure partial tasks are not tracked.
- Repro (observed in production)
  - Inbound INVITE followed by quick CANCEL
  - Feature server attempts to initialize background transcribe; logs:
    - “BackgroundTaskManager:_initTranscribe - Error creating transcribe task”
    - “Response#send: final response already sent”
  - Teardown triggers `BackgroundTaskManager.stopAll()`
  - Crash:
    - TypeError: Cannot read properties of undefined (reading 'end') at background-task-manager.js:67:17
- Root cause
  - `stop`/`_taskCompleted`/`_taskError` unconditionally call `task.span.end()`
  - Init methods return a task even if initialization fails before `task.span` assignment
  - `newTask` stores tasks regardless of initialization completeness
- Changes
  - Guard `task.span.end()` in `stop`, `_taskCompleted`, `_taskError`
  - Only track tasks in `newTask` when `task.span` exists (fully initialized)
  - In `_initListen`, `_initBargeIn`, `_initTranscribe`, `_initTtsStream`, return `undefined` in catch blocks
- Why this approach
  - Keeps existing behavior intact for successful flows while making teardown idempotent and safe
  - Eliminates class of crashes from partial initialization and teardown races
- Compatibility
  - No API changes
  - Logging preserved; spans end when present
