### PR TITLE
if call is transferred from another FS then always answer

### DIFF
--- a/lib/session/call-session.js
+++ b/lib/session/call-session.js
@@ -2399,7 +2399,7 @@ Duration=${duration} `
         this.logger.debug(`endpoint was destroyed!! ${this.ep.uuid}`);
       });
 
-      if (this.direction === CallDirection.Inbound) {
+      if (this.direction === CallDirection.Inbound || this.application?.transferredCall) {
         if (task.earlyMedia && !this.req.finalResponseSent) {
           this.res.send(183, {body: ep.local.sdp});
           return {ep};


### PR DESCRIPTION
Currently if the call being transferred was originally an outbound call then the direction thats retrieved from redis is outbound and the invite of the refer from the other FS is never answered, However a transferredCall will always need to be answered regardless of CallDirection.

Fixes #1380 