### PR TITLE
Fixed handling of bargein and dtmfBargein parameters.

### DIFF
--- a/lib/tasks/gather.js
+++ b/lib/tasks/gather.js
@@ -80,7 +80,10 @@ class TaskGather extends SttTask {
     if (this.play) {
       this.playTask = makeTask(this.logger, {play: this.play}, this);
     }
-    if (!this.sayTask && !this.playTask) this.listenDuringPrompt = false;
+    if (!this.sayTask && !this.playTask) {
+      this.listenDuringPrompt = false;
+      this.playComplete = true; // No prompt, so consider it complete from the start
+    }
 
     /* buffer speech for continuous asr */
     this._bufferedTranscripts = [];
@@ -252,6 +255,16 @@ class TaskGather extends SttTask {
             startDtmfListener();
           }
           this._stopVad();
+          // Check if we have buffered input ready (when bargein was disabled)
+          if (this._inputReady && !this.killed && !this.resolved) {
+            this.logger.debug(`Gather: prompt complete and input ready (${this._inputType}), resolving now`);
+            if (this._inputType === 'dtmf') {
+              this._resolve('dtmf-num-digits');
+            } else if (this._inputType === 'speech') {
+              this._resolve('speech', this._speechEvent);
+            }
+            return;
+          }
           if (!this.killed) {
             startListening(cs, ep);
             if (this.input.includes('speech') && this.vendor === 'nuance' && this.listenDuringPrompt) {
@@ -288,6 +301,16 @@ class TaskGather extends SttTask {
             startDtmfListener();
           }
           this._stopVad();
+          // Check if we have buffered input ready (when bargein was disabled)
+          if (this._inputReady && !this.killed && !this.resolved) {
+            this.logger.debug(`Gather: prompt complete and input ready (${this._inputType}), resolving now`);
+            if (this._inputType === 'dtmf') {
+              this._resolve('dtmf-num-digits');
+            } else if (this._inputType === 'speech') {
+              this._resolve('speech', this._speechEvent);
+            }
+            return;
+          }
           if (!this.killed) {
             startListening(cs, ep);
             if (this.input.includes('speech') && this.vendor === 'nuance' && this.listenDuringPrompt) {
@@ -401,8 +424,15 @@ class TaskGather extends SttTask {
       this.digitBuffer += evt.dtmf;
       const len = this.digitBuffer.length;
       if (len === this.numDigits || len === this.maxDigits) {
-        resolved = true;
-        this._resolve('dtmf-num-digits');
+        // Only resolve immediately if dtmfBargein is enabled, otherwise wait for prompt to complete or timeout
+        if (this.dtmfBargein) {
+          resolved = true;
+          this._resolve('dtmf-num-digits');
+        } else {
+          this.logger.debug('TaskGather:_onDtmf - sufficient digits collected but dtmfBargein=false, waiting for prompt completion');
+          this._inputReady = true;
+          this._inputType = 'dtmf';
+        }
       }
     }
     if (!resolved && this.interDigitTimeout > 0 && this.digitBuffer.length >= this.minDigits) {
@@ -1031,7 +1061,15 @@ class TaskGather extends SttTask {
         }
 
         /* here is where we return a final transcript */
-        this._resolve('speech', evt);
+        // Only resolve immediately if bargein is enabled, otherwise wait for prompt to complete or timeout
+        if (this.bargein || this.playComplete) {
+          this._resolve('speech', evt);
+        } else {
+          this.logger.debug('TaskGather:_onTranscription - final transcript received but bargein=false, waiting for prompt completion');
+          this._inputReady = true;
+          this._inputType = 'speech';
+          this._speechEvent = evt;
+        }
         /*}*/
       }
     }
@@ -1288,9 +1326,10 @@ class TaskGather extends SttTask {
     }
 
     this.resolved = true;
-    // If bargin is false and ws application return ack to verb:hook
-    // the gather should not play any audio
-    this._killAudio(this.cs);
+    // Kill audio only if prompt is still playing (bargein scenario or timeout during prompt)
+    if (!this.playComplete) {
+      this._killAudio(this.cs);
+    }
     // Clear dtmf events, to avoid any case can leak the listener, just clean it
     this.ep.removeAllListeners('dtmf');
     clearTimeout(this.interDigitTimer);


### PR DESCRIPTION
### This change fixes the following test cases
```
let say = {
      text: text,
      synthesizer: googleSpeech,
    };
let recognizer = {
        vendor: 'google',
        language: 'en-US',
      };
let promptParams = {
      actionHook: '/loop',
      input: ['digits', 'speech'],
      timeout: 10,
      say: say,
      recogniser: recognizer,
}
```

### Case 1
```
let promptParams = {
      dtmfBargein: false,
      maxDigits:1,
    };
```
Expected: Bargein with DTMF doesn’t happen
Result Bargein with either DTMF or speech still happens

### Case 2
```
let promptParams = {
      bargein: false,
      dtmfBargein: false,
      maxDigits:1,
    };
```
Expected: Bargein with DTMF or Speech doesn’t happen
Result Barge-in with either DTMF or speech still happens

### Case 3
```
let promptParams = {
      listenDuringPrompt: true,
      bargein: true,
      dtmfBargein: true,
      maxDigits:1,
    };
```
Expected: User can bargein prompts with DTMF or speech. Bardein happens almost immediately after a DTMF or speech input.

Result: Bargein with DTMF works as expected; Bargein with speech behaves badly. Sometimes bargein happens on no speech input—background noise? Sometimes prompts are interrupted either on the first spoken word or on the second or even third. The user app may receive all of the spoken words or only the first spoken word when interrupted after the second spoken word.

### Case 4
```
let promptParams = {
      listenDuringPrompt: true,
      bargein: false,
      dtmfBargein: false,
      maxDigits:1,
    };
```
Expected: prompt plays to the end
Result: prompt interrupted with either speech or DTMF. 