### PR TITLE
fixed does not send final status call back if call canceled quickly

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -119,7 +119,6 @@ module.exports = function(srf, logger) {
     req.once('cancel', (sipMsg) => {
       logger.info(`${callId} got CANCEL request`);
       req.locals.canceled = true;
-      req.locals.cancelSipMsg = sipMsg;
     });
     next();
   }

--- a/lib/session/call-session.js
+++ b/lib/session/call-session.js
@@ -1230,11 +1230,6 @@ class CallSession extends Emitter {
    * @async
    */
   async exec() {
-    // race condition that call has been canceled before we started executing
-    if (this.req?.locals.canceled) {
-      this.logger.info('CallSession:exec - call was canceled before we started executing');
-      this.req.emit('canceled', this.req.locals.cancelSipMsg);
-    }
     this.logger.info({tasks: listTaskNames(this.tasks)}, `CallSession:exec starting ${this.tasks.length} tasks`);
 
     // calculate if inbandDTMF tone is used

--- a/lib/session/inbound-call-session.js
+++ b/lib/session/inbound-call-session.js
@@ -22,6 +22,12 @@ class InboundCallSession extends CallSession {
     this.req = req;
     this.res = res;
 
+    // if the call was canceled before we got here, handle it
+    if (this.req.locals.canceled) {
+      req.locals.logger.info('InboundCallSession: constructor - call was already canceled');
+      this._onCancel();
+    }
+
     req.once('cancel', this._onCancel.bind(this));
 
     this.on('callStatusChange', this._notifyCallStatusChange.bind(this));


### PR DESCRIPTION
There is race condition that jambonz is fetching app json and caller canceled the call.
Jambonz does not send final status callback as well as close the ws application connection

https://jambonz.freshdesk.com/a/tickets/1494