### PR TITLE
escape json special chars in metadata

### DIFF
--- a/lib/tasks/listen.js
+++ b/lib/tasks/listen.js
@@ -5,6 +5,17 @@ const moment = require('moment');
 const MAX_PLAY_AUDIO_QUEUE_SIZE = 10;
 const DTMF_SPAN_NAME = 'dtmf';
 
+function escapeString(str) {
+  return str
+    .replace(/\\/g, '\\\\')   // Escape backslashes
+    .replace(/"/g, '\\"')     // Escape double quotes
+    .replace(/\b/g, '\\b')    // Escape backspace
+    .replace(/\f/g, '\\f')    // Escape formfeed
+    .replace(/\n/g, '\\n')    // Escape newlines
+    .replace(/\r/g, '\\r')    // Escape carriage returns
+    .replace(/\t/g, '\\t');   // Escape tabs
+}
+
 class TaskListen extends Task {
   constructor(logger, opts, parentTask) {
     super(logger, opts);
@@ -16,9 +27,19 @@ class TaskListen extends Task {
     this.preconditions = TaskPreconditions.Endpoint;
 
     [
-      'action', 'auth', 'method', 'url', 'finishOnKey', 'maxLength', 'metadata', 'mixType', 'passDtmf', 'playBeep',
+      'action', 'auth', 'method', 'url', 'finishOnKey', 'maxLength', 'mixType', 'passDtmf', 'playBeep',
       'sampleRate', 'timeout', 'transcribe', 'wsAuth', 'disableBidirectionalAudio', 'channel'
     ].forEach((k) => this[k] = this.data[k]);
+
+    //Escape JSON special characters in metadata
+    if (this.data.metadata) {
+      this.metadata = {};
+      for (const key in this.data.metadata) {
+        if (this.data.metadata.hasOwnProperty(key)) {
+          this.metadata[key] = escapeString(this.data.metadata[key]);
+        }
+      }
+    }
 
     this.mixType = this.mixType || 'mono';
     this.sampleRate = this.sampleRate || 8000;


### PR DESCRIPTION
fixes #1398 

Tested with a metadata object of:
```
"metadata": {
      "plain": "test message",
      "backslash": "\\\\Backslash",
      "quotes": "\"4567\"",
      "backspace": "Testy\\b",
      "formfeed": "Test\\fFeed",
      "newline": "Test\\nLine",
      "cariage_return": "Test\\rReturn",
      "tab": "Test\\tTab"
    }
  ```
  All strings recieved and parsed as JSON on the websocket
  
  Also tested listen with no metadata and an empty object.
  