### PR TITLE
Add ability to disable TTS cache for entire call session.

### DIFF
--- a/lib/tasks/config.js
+++ b/lib/tasks/config.js
@@ -18,7 +18,8 @@ class TaskConfig extends Task {
       'boostAudioSignal',
       'vad',
       'ttsStream',
-      'autoStreamTts'
+      'autoStreamTts',
+      'disableTtsCache'
     ].forEach((k) => this[k] = this.data[k] || {});
 
     if ('notifyEvents' in this.data) {
@@ -96,6 +97,7 @@ class TaskConfig extends Task {
     if (this.data.reset.length) phrase.push(`reset ${this.data.reset.join(',')}`);
 
     if (this.bargeIn.enable) phrase.push('enable barge-in');
+    if (this.disableTtsCache) phrase.push(`disableTtsCache ${this.disableTtsCache ? 'true' : 'false'}`);
     if (this.hasSynthesizer) {
       const {vendor:v, language:l, voice, label} = this.synthesizer;
       const s = `{${v},${l},${voice},${label || 'None'}}`;
@@ -356,6 +358,11 @@ class TaskConfig extends Task {
     else if (this.ttsStream.enable === false) {
       this.logger.info('Config: disabling ttsStream');
       cs.disableTtsStream();
+    }
+
+    if (this.disableTtsCache) {
+      this.logger.info('Config: disable TtsCache');
+      cs.disableTtsCache = this.disableTtsCache;
     }
   }
 

--- a/lib/tasks/say.js
+++ b/lib/tasks/say.js
@@ -342,7 +342,9 @@ class TaskSay extends TtsTask {
                 evt.variable_tts_cache_filename &&
                 !this.killed &&
                 // if tts cache is not disabled, add the file to cache
-                !this.disableTtsCache
+                !this.disableTtsCache &&
+                // has tts cache been disabled for the entire session
+                !cs.disableTtsCache
               ) {
                 const text = parseTextFromSayString(this.text[segment]);
                 this.logger.debug({text, cacheFile: evt.variable_tts_cache_filename}, 'Say:exec cache tts');


### PR DESCRIPTION
You can now pass a config parameter: disableTtsCache, which will allow tts caching to be disabled/enabled for the entire call session.