### PR TITLE
fd_1574: should not send only whitespace to streaming tts engine

### DIFF
--- a/lib/utils/tts-streaming-buffer.js
+++ b/lib/utils/tts-streaming-buffer.js
@@ -278,6 +278,14 @@ class TtsStreamingBuffer extends Emitter {
       }
       const chunk = combinedText.slice(0, chunkEnd);
 
+      // Check if the chunk is only whitespace before processing the queue
+      // If so, wait for more meaningful text
+      if (isWhitespace(chunk)) {
+        this.logger.debug('TtsStreamingBuffer:_feedQueue chunk is only whitespace, waiting for more text');
+        this._setTimerIfNeeded();
+        return;
+      }
+
       // Now we iterate over the queue items
       // and deduct their lengths until we've accounted for chunkEnd characters.
       let remaining = chunkEnd;
@@ -301,6 +309,14 @@ class TtsStreamingBuffer extends Emitter {
       this.bufferedLength -= chunkEnd;
 
       const modifiedChunk = chunk.replace(/\n\n/g, '\n \n');
+
+      if (isWhitespace(modifiedChunk)) {
+        this.logger.debug('TtsStreamingBuffer:_feedQueue modified chunk is only whitespace, restoring queue');
+        this.queue.unshift({ type: 'text', value: chunk });
+        this.bufferedLength += chunkEnd;
+        this._setTimerIfNeeded();
+        return;
+      }
       this.logger.debug(`TtsStreamingBuffer:_feedQueue sending chunk to tts: ${modifiedChunk}`);
 
       try {


### PR DESCRIPTION
https://jambonz.freshdesk.com/a/tickets/1574

When tts streaming buffer is just only white space, feature server will send that token to freeswitch, and esl will trim that white space that make freeswitch module return error that send command have to have 3 parameters.

solution is that, before sending tokens, feature verser have to check if it's white space, if yes, put that back to buffer token and wait for another round.