### PR TITLE
Add ability to enable/disable Azure audio logging via  azureOptions

### DIFF
--- a/lib/utils/transcription-utils.js
+++ b/lib/utils/transcription-utils.js
@@ -920,7 +920,7 @@ module.exports = (logger) => {
         ...(rOpts.initialSpeechTimeoutMs > 0 &&
           {AZURE_INITIAL_SPEECH_TIMEOUT_MS: rOpts.initialSpeechTimeoutMs}),
         ...(rOpts.requestSnr && {AZURE_REQUEST_SNR: 1}),
-        ...(rOpts.audioLogging && {AZURE_AUDIO_LOGGING: 1}),
+        ...(azureOptions.audioLogging && {AZURE_AUDIO_LOGGING: 1}),
         ...{AZURE_USE_OUTPUT_FORMAT_DETAILED: 1},
         ...(azureOptions.speechSegmentationSilenceTimeoutMs &&
           {AZURE_SPEECH_SEGMENTATION_SILENCE_TIMEOUT_MS: azureOptions.speechSegmentationSilenceTimeoutMs}),


### PR DESCRIPTION
audio logging was essentially a noop and always default to off, allow enabling through the Recognizer - azureOptions 