### PR TITLE
when dialing the B leg we check to see if we are using opus on the A …

### DIFF
--- a/lib/tasks/dial.js
+++ b/lib/tasks/dial.js
@@ -576,7 +576,7 @@ class TaskDial extends Task {
       proxy: `sip:${sbcAddress}`,
       callingNumber: this.callerId || fromUri.user,
       ...(this.callerName && {callingName: this.callerName}),
-      opusFirst: isOpusFirst(this.cs.ep.remote.sdp),
+      opusFirst: isOpusFirst(this.cs.ep.local.sdp),
       isVideoCall: this.cs.ep.remote.sdp.includes('m=video')
     };
 


### PR DESCRIPTION
…leg, and if so we outdial B with opus first; however we were incorrectly checking the SDP on the A leg invite not the 200 OK we send back