### PR TITLE
fix: use correct FreeSWITCH variable name for hold music

### DIFF
--- a/lib/utils/media-endpoint.js
+++ b/lib/utils/media-endpoint.js
@@ -22,7 +22,7 @@ const createMediaEndpoint = async(srf, logger, {
 
   // Configure the endpoint
   const opts = {
-    ...(onHoldMusic && {holdMusic: `shout://${onHoldMusic.replace(/^https?:\/\//, '')}`}),
+    ...(onHoldMusic && {hold_music: `shout://${onHoldMusic.replace(/^https?:\/\//, '')}`}),
     ...(JAMBONES_USE_FREESWITCH_TIMER_FD && {timer_name: 'timerfd'}),
     ...(JAMBONES_MEDIA_TIMEOUT_MS && {media_timeout: JAMBONES_MEDIA_TIMEOUT_MS}),
     ...(JAMBONES_MEDIA_HOLD_TIMEOUT_MS && {media_hold_timeout: JAMBONES_MEDIA_HOLD_TIMEOUT_MS})


### PR DESCRIPTION
The onHoldMusic config option was not working because the code set the FreeSWITCH channel variable as holdMusic (camelCase), but FreeSWITCH's automatic hold music feature expects hold_music (snake_case).                                                                                                                                                             

  This caused FreeSWITCH to fall back to the default local_stream://moh instead of using the configured URL when a call is placed on hold via SIP re-INVITE with a=sendonly.