### PR TITLE
Fix boostAudioSignal parameter in Update Call REST API

### DIFF
--- a/lib/session/call-session.js
+++ b/lib/session/call-session.js
@@ -2028,7 +2028,7 @@ Duration=${duration} `
         return this._lccDub(opts.dub, callSid);
       }
       else if (opts.boostAudioSignal) {
-        return this._lccBoostAudioSignal(opts, callSid);
+        return this._lccBoostAudioSignal(opts.boostAudioSignal, callSid);
       }
       else if (opts.media_path) {
         return this._lccMediaPath(opts.media_path, callSid);


### PR DESCRIPTION
## Summary
   - Fixes the parameter passed to `_lccBoostAudioSignal` to use `opts.boostAudioSignal` instead of the entire `opts` object
   - This ensures the boostAudioSignal option works correctly in the Update Call REST API


## Explanation of fix

Currently, `opts` looks something like `{"boostAudioSignal": "-10 db"}`
and the _lccBoostAudioSignal function does:
```
const db = parseDecibels(opts)

const parseDecibels = (db) => {
  if (!db) return 0;
  if (typeof db === 'number') {
    return db;
  }
  else if (typeof db === 'string') {
    const match = db.match(/([+-]?\d+(\.\d+)?)\s*db/i);
    if (match) {
      return Math.trunc(parseFloat(match[1]));
    } else {
      return 0;
    }
  } else {
    return 0;
  }
};
```
Therefore, the parseDecibels function is always returning the default 0 db (ignoring what the user sent in).

By updating the parameter for _lccBoostAudioSignal to be the actual decibel value, the function now works correctly.