### PR TITLE
add x-reason to sip-decline

### DIFF
--- a/lib/tasks/sip_decline.js
+++ b/lib/tasks/sip_decline.js
@@ -17,7 +17,7 @@ class TaskSipDecline extends Task {
   async exec(cs, {res}) {
     super.exec(cs);
     res.send(this.data.status, this.data.reason, {
-      headers: {'X-Verb': 'SIP Decline', ...this.headers}
+      headers: {'X-Reason': 'SIP Decline Verb', ...this.headers}
     }, (err) => {
       if (!err) {
         // Call was successfully declined

--- a/lib/tasks/sip_decline.js
+++ b/lib/tasks/sip_decline.js
@@ -17,7 +17,7 @@ class TaskSipDecline extends Task {
   async exec(cs, {res}) {
     super.exec(cs);
     res.send(this.data.status, this.data.reason, {
-      headers: {"X-Verb": "SIP Decline", ...this.headers}
+      headers: {'X-Verb': 'SIP Decline', ...this.headers}
     }, (err) => {
       if (!err) {
         // Call was successfully declined

--- a/lib/tasks/sip_decline.js
+++ b/lib/tasks/sip_decline.js
@@ -17,7 +17,7 @@ class TaskSipDecline extends Task {
   async exec(cs, {res}) {
     super.exec(cs);
     res.send(this.data.status, this.data.reason, {
-      headers: this.headers
+      headers: {"X-Verb": "SIP Decline", ...this.headers}
     }, (err) => {
       if (!err) {
         // Call was successfully declined


### PR DESCRIPTION
This helps with identifying apps that are sending a decline when looking at 404'd calls from the PCAP without needing to go check the feature-server logs.

The X-reason header is already used by jambonz in some scenarios where the SBC rejects the call