### PR TITLE
Send alert on invalid verb response to gather actionHook

### DIFF
--- a/lib/tasks/gather.js
+++ b/lib/tasks/gather.js
@@ -1424,7 +1424,26 @@ class TaskGather extends SttTask {
           returnedVerbs = await this.performAction({speech:evt, reason: 'stt-low-confidence', ...latencies});
         }
       }
-    } catch (err) {  /*already logged error*/ }
+    } catch (err) {
+      this.logger.info({err}, 'TaskGather:_resolve - error performing action');
+      this.notifyError({msg: 'invalid actionHook response', details: err.message});
+      const {writeAlerts, AlertType} = this.cs.srf.locals;
+      writeAlerts({
+        account_sid: this.cs.accountSid,
+        alert_type: AlertType.INVALID_APP_PAYLOAD,
+        target_sid: this.cs.callSid,
+        message: `actionHook returned invalid verb syntax: ${err.message}`
+      }).catch((err) => this.logger.info({err}, 'TaskGather:_resolve - error generating alert'));
+      try {
+        const obj = Object.assign({}, this.cs.callInfo.toJSON(), {
+          error: 'invalid actionHook response',
+          reason: err.message
+        });
+        await this.cs.notifier.request('call:status', this.cs.call_status_hook, obj);
+      } catch (statusErr) {
+        this.logger.info({statusErr}, 'TaskGather:_resolve - error sending statusHook');
+      }
+    }
 
     // Gather got response from hook, cancel actionHookDelay processing
     if (this.cs.actionHookDelayProcessor) {


### PR DESCRIPTION
fixes #1424 
This now generates an alert visible in the webui, sends an error statushook and writes to the feature-server log if the actionHook returns invalid verb data.
This is consistent with other actionHooks
<img width="1185" height="450" alt="Screen Shot 2026-03-18 at 10 18 06 AM" src="https://github.com/user-attachments/assets/e3484107-29ec-407a-b778-7724c80c74f8" />
<img width="463" height="484" alt="Screen Shot 2026-03-18 at 10 18 19 AM" src="https://github.com/user-attachments/assets/5322013b-71ac-4f7c-8c1a-faba4dd33f35" />
```
205|jambon | {"level":30,"time":1773827227230,"pid":593335,"hostname":"ip-172-31-10-100","callId":"41906ba3-9d52-123f-3591-025b5fe5ea1d","callSid":"ee709f54-f600-4ab5-8788-c3ccda70a8c2","accountSid":"96eb12d7-3217-45bd-be69-537764dbb7f4","callingNumber":"1001","calledNumber":"7001","traceId":"559c9927d072dc0dc3c2908ceed50bfa","err":{"type":"Error","message":"invalid instruction: blah","stack":"Error: invalid instruction: blah\n    at validateVerb (/home/admin/apps/jambonz-feature-server/node_modules/@jambonz/verb-specifications/jambonz-app-json-validation.js:50:31)\n    at makeTask (/home/admin/apps/jambonz-feature-server/lib/tasks/make_task.js:15:3)\n    at /home/admin/apps/jambonz-feature-server/lib/tasks/task.js:191:77\n    at Array.map (<anonymous>)\n    at TaskGather.performAction (/home/admin/apps/jambonz-feature-server/lib/tasks/task.js:191:62)\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async TaskGather._resolve (/home/admin/apps/jambonz-feature-server/lib/tasks/gather.js:1394:27)"},"msg":"TaskGather:_resolve - error performing action"}
```