### PR TITLE
Fix/hangup call

### DIFF
--- a/lib/http-routes/api/error.js
+++ b/lib/http-routes/api/error.js
@@ -7,7 +7,7 @@ function sysError(logger, res, err) {
   }
   if (err instanceof DbErrorUnprocessableRequest) {
     logger.info({message: err.message}, 'unprocessable request');
-    return res.status(422).json({msg: err.message});
+    return res.status(422).send(err.message);
   }
   if (err.code === 'ER_DUP_ENTRY') {
     logger.info(err, 'duplicate entry on insert');

--- a/lib/http-routes/api/error.js
+++ b/lib/http-routes/api/error.js
@@ -6,7 +6,7 @@ function sysError(logger, res, err) {
     return res.status(400).json({msg: err.message});
   }
   if (err instanceof DbErrorUnprocessableRequest) {
-    logger.info(err, 'unprocessable request');
+    logger.info({message: err.message}, 'unprocessable request');
     return res.status(422).json({msg: err.message});
   }
   if (err.code === 'ER_DUP_ENTRY') {


### PR DESCRIPTION
update info log to remove stack trace as this is only called in specific locations each with thier own descriptive message
```
update-call.js (4 throw sites):

Line 17: call session is gone for call_sid
Line 21: current call state is incompatible with requested action (no stable dialog)
Line 27: same message (outbound not ringing)
Line 33: same message (inbound already answered)
conference.js (line 15):

conference api failure: indicated call is not waiting
enqueue.js (line 17):

enqueue api failure: indicated call is not queued
dequeue.js (line 15):

dequeue api failure: indicated call is not queued
```
Also this is not really a failure of jambonz its just a user/state error so haivng a simple info message is clearer in the logs, also updated the message response text so that its passed through the api server to the requsting client