### PR TITLE
ensure traceId is set on CallRecord

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -28,6 +28,7 @@ module.exports = function(srf, logger) {
     registrar,
     lookupClientByAccountAndUsername
   }  = srf.locals.dbHelpers;
+  const {addKey} = srf.locals.dbHelpers;
   const {
     writeAlerts,
     AlertType
@@ -141,6 +142,14 @@ module.exports = function(srf, logger) {
         traceId}),
       rootSpan
     };
+
+    /* write a short-lived Redis key mapping the original Call-ID (X-CID) to the traceId,
+       so sbc-inbound can look it up for CDRs even when a CANCEL is sent to sbc-inbound */
+    const externalCallId = req.get('X-CID');
+    if (externalCallId) {
+      addKey(`callid:${externalCallId}`, traceId, 300)
+        .catch((err) => logger.error(err, 'createRootSpan: error writing traceId to Redis'));
+    }
 
     /**
      * end the span on final failure or cancel from caller;

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -28,7 +28,6 @@ module.exports = function(srf, logger) {
     registrar,
     lookupClientByAccountAndUsername
   }  = srf.locals.dbHelpers;
-  const {addKey} = srf.locals.dbHelpers;
   const {
     writeAlerts,
     AlertType
@@ -142,14 +141,6 @@ module.exports = function(srf, logger) {
         traceId}),
       rootSpan
     };
-
-    /* write a short-lived Redis key mapping the original Call-ID (X-CID) to the traceId,
-       so sbc-inbound can look it up for CDRs even when a CANCEL is sent to sbc-inbound */
-    const externalCallId = req.get('X-CID');
-    if (externalCallId) {
-      addKey(`callid:${externalCallId}`, traceId, 300)
-        .catch((err) => logger.error(err, 'createRootSpan: error writing traceId to Redis'));
-    }
 
     /**
      * end the span on final failure or cancel from caller;

--- a/lib/session/call-session.js
+++ b/lib/session/call-session.js
@@ -1495,7 +1495,12 @@ class CallSession extends Emitter {
     else if (opts.call_status === CallStatus.NoAnswer) {
       if (this.direction === CallDirection.Inbound) {
         if (this.res && !this.res.finalResponseSent) {
-          this.res.send(503);
+          const traceId = this.req?.locals?.traceId;
+          this.res.send(503, {
+            headers: {
+              ...(traceId && {'X-Trace-ID': traceId})
+            }
+          });
           this._callReleased();
         }
       }
@@ -2530,10 +2535,12 @@ Duration=${duration} `
           // Send SIP error response immediately for inbound calls
           if (this.res && !this.res.finalResponseSent) {
             this.logger.info(`Sending ${err.status} response to SBC due to SipError`);
+            const traceId = this.req?.locals?.traceId;
             this.res.send(err.status, {
               headers: {
                 'X-Reason': `endpoint allocation failure: ${err.reason || 'Endpoint Allocation Failed'}`,
-                ...(sipReasonHeader && {'Reason': sipReasonHeader})
+                ...(sipReasonHeader && {'Reason': sipReasonHeader}),
+                ...(traceId && {'X-Trace-ID': traceId})
               }
             });
             this._notifyCallStatusChange({

--- a/lib/session/call-session.js
+++ b/lib/session/call-session.js
@@ -192,6 +192,15 @@ class CallSession extends Emitter {
     return this.callInfo.applicationSid;
   }
 
+  get _traceHeaders() {
+    const traceId = this.req?.locals?.traceId;
+    const applicationSid = this.applicationSid;
+    return {
+      ...(traceId && {'X-Trace-ID': traceId}),
+      ...(applicationSid && {'X-Application-Sid': applicationSid})
+    };
+  }
+
   get callStatus() {
     return this.callInfo.callStatus;
   }
@@ -1495,12 +1504,7 @@ class CallSession extends Emitter {
     else if (opts.call_status === CallStatus.NoAnswer) {
       if (this.direction === CallDirection.Inbound) {
         if (this.res && !this.res.finalResponseSent) {
-          const traceId = this.req?.locals?.traceId;
-          this.res.send(503, {
-            headers: {
-              ...(traceId && {'X-Trace-ID': traceId})
-            }
-          });
+          this.res.send(503, {headers: this._traceHeaders});
           this._callReleased();
         }
       }
@@ -2535,12 +2539,11 @@ Duration=${duration} `
           // Send SIP error response immediately for inbound calls
           if (this.res && !this.res.finalResponseSent) {
             this.logger.info(`Sending ${err.status} response to SBC due to SipError`);
-            const traceId = this.req?.locals?.traceId;
             this.res.send(err.status, {
               headers: {
                 'X-Reason': `endpoint allocation failure: ${err.reason || 'Endpoint Allocation Failed'}`,
                 ...(sipReasonHeader && {'Reason': sipReasonHeader}),
-                ...(traceId && {'X-Trace-ID': traceId})
+                ...this._traceHeaders
               }
             });
             this._notifyCallStatusChange({

--- a/lib/session/inbound-call-session.js
+++ b/lib/session/inbound-call-session.js
@@ -51,12 +51,14 @@ class InboundCallSession extends CallSession {
 
   _onTasksDone() {
     if (!this.res.finalResponseSent) {
+      const traceId = this.req.locals.traceId;
       if (this._mediaServerFailure) {
         this.rootSpan.setAttributes({'call.termination': 'media server failure'});
         this.logger.info('InboundCallSession:_onTasksDone generating 480 due to media server failure');
         this.res.send(480, {
           headers: {
-            'X-Reason': 'crankback: media server failure'
+            'X-Reason': 'crankback: media server failure',
+            ...(traceId && {'X-Trace-ID': traceId})
           }
         });
       }
@@ -69,14 +71,19 @@ class InboundCallSession extends CallSession {
         this.res.send(status, {
           headers: {
             'X-Reason': `endpoint allocation failure: ${reason}`,
-            ...(sipReasonHeader && {'Reason': sipReasonHeader})
+            ...(sipReasonHeader && {'Reason': sipReasonHeader}),
+            ...(traceId && {'X-Trace-ID': traceId})
           }
         });
       }
       else {
         this.rootSpan.setAttributes({'call.termination': 'tasks completed without answering call'});
         this.logger.info('InboundCallSession:_onTasksDone auto-generating non-success response to invite');
-        this.res.send(603);
+        this.res.send(603, {
+          headers: {
+            ...(traceId && {'X-Trace-ID': traceId})
+          }
+        });
       }
     }
     this.req.removeAllListeners('cancel');

--- a/lib/session/inbound-call-session.js
+++ b/lib/session/inbound-call-session.js
@@ -51,14 +51,13 @@ class InboundCallSession extends CallSession {
 
   _onTasksDone() {
     if (!this.res.finalResponseSent) {
-      const traceId = this.req.locals.traceId;
       if (this._mediaServerFailure) {
         this.rootSpan.setAttributes({'call.termination': 'media server failure'});
         this.logger.info('InboundCallSession:_onTasksDone generating 480 due to media server failure');
         this.res.send(480, {
           headers: {
             'X-Reason': 'crankback: media server failure',
-            ...(traceId && {'X-Trace-ID': traceId})
+            ...this._traceHeaders
           }
         });
       }
@@ -72,18 +71,14 @@ class InboundCallSession extends CallSession {
           headers: {
             'X-Reason': `endpoint allocation failure: ${reason}`,
             ...(sipReasonHeader && {'Reason': sipReasonHeader}),
-            ...(traceId && {'X-Trace-ID': traceId})
+            ...this._traceHeaders
           }
         });
       }
       else {
         this.rootSpan.setAttributes({'call.termination': 'tasks completed without answering call'});
         this.logger.info('InboundCallSession:_onTasksDone auto-generating non-success response to invite');
-        this.res.send(603, {
-          headers: {
-            ...(traceId && {'X-Trace-ID': traceId})
-          }
-        });
+        this.res.send(603, {headers: this._traceHeaders});
       }
     }
     this.req.removeAllListeners('cancel');

--- a/lib/tasks/sip_decline.js
+++ b/lib/tasks/sip_decline.js
@@ -17,7 +17,11 @@ class TaskSipDecline extends Task {
   async exec(cs, {res}) {
     super.exec(cs);
     res.send(this.data.status, this.data.reason, {
-      headers: {'X-Reason': 'SIP Decline Verb', ...this.headers}
+      headers: {
+        'X-Reason': 'SIP Decline Verb',
+        ...this.headers,
+        ...cs._traceHeaders
+      }
     }, (err) => {
       if (!err) {
         // Call was successfully declined


### PR DESCRIPTION
Fix for https://github.com/jambonz/jambonz-feature-server/issues/1505
Corresponding change in sbc-inbound: https://github.com/jambonz/sbc-inbound/pull/240

These changes ensure an X-Trace-Id is added to the error responses sent to sbc-inbound. 
I also added a Redis entry with the traceId keyed to the callId, so that there is still a traceId on Call Records when either the user hangs up before the call is answered or the application doesn't provide an actionHook to handle a failed dial, thereby resulting in the caller hanging up due to lack of a final response making it back to sbc-inbound.