### PR TITLE
add null check for eventHook

### DIFF
--- a/lib/tasks/llm/index.js
+++ b/lib/tasks/llm/index.js
@@ -105,6 +105,7 @@ class TaskLlm extends Task {
   }
 
   async sendEventHook(data) {
+    if (!this.eventHook) return;
     await this.cs?.requestor.request('llm:event', this.eventHook, data);
   }
 

--- a/lib/tasks/llm/llms/ultravox_s2s.js
+++ b/lib/tasks/llm/llms/ultravox_s2s.js
@@ -286,6 +286,10 @@ class TaskLlmUltravox_S2S extends Task {
   }
 
   _sendLlmEvent(type, evt) {
+    if (!this.eventHook) {
+      this.logger.info({evt}, 'TaskLlmUltravox_S2S:_sendLlmEvent - no eventHook defined!');
+      return;
+    }
     /* check whether we should notify on this event */
     if (this.includeEvents.length > 0 ? this.includeEvents.includes(type) : !this.excludeEvents.includes(type)) {
       this.parent.sendEventHook(evt)

--- a/lib/tasks/llm/llms/ultravox_s2s.js
+++ b/lib/tasks/llm/llms/ultravox_s2s.js
@@ -286,10 +286,6 @@ class TaskLlmUltravox_S2S extends Task {
   }
 
   _sendLlmEvent(type, evt) {
-    if (!this.eventHook) {
-      this.logger.info({evt}, 'TaskLlmUltravox_S2S:_sendLlmEvent - no eventHook defined!');
-      return;
-    }
     /* check whether we should notify on this event */
     if (this.includeEvents.length > 0 ? this.includeEvents.includes(type) : !this.excludeEvents.includes(type)) {
       this.parent.sendEventHook(evt)


### PR DESCRIPTION
Fixes TypeError when no eventHook was defined on the Llm verb.