### PR TITLE
add evt check in mediaTimeoutHandler

### DIFF
--- a/lib/utils/place-outdial.js
+++ b/lib/utils/place-outdial.js
@@ -151,6 +151,7 @@ class SingleDialer extends Emitter {
       let lastSdp;
       const connectStream = async(remoteSdp, isVideoCall) => {
         if (remoteSdp === lastSdp) return;
+        if (!this.ep) return;
         if (process.env.JAMBONES_VIDEO_CALLS_ENABLED_IN_FS && !isVideoCall) {
           remoteSdp = removeVideoSdp(remoteSdp);
         }
@@ -360,8 +361,10 @@ class SingleDialer extends Emitter {
   }
 
   async _handleMediaTimeout(evt, ep) {
-    this.logger.info({evt}, 'SingleDialer:_handleMediaTimeout - media timeout event received');
-    this.dialTask.kill(this.dialTask.cs, 'media-timeout');
+    if (evt?.reason === 'MEDIA_TIMEOUT') {
+      this.logger.info({evt}, 'SingleDialer:_handleMediaTimeout - media timeout event received');
+      this.dialTask.kill(this.dialTask.cs, 'media-timeout');
+    }
   }
 
   async _createMediaEndpoint(drachtioFsmrfOptions = {}) {


### PR DESCRIPTION
Added a check for the event reason to make sure it actually is a media timeout, and added null check for endpoint. Support ticket #2170 identified a scenario where a broken pipe on the FreeSWITCH connection was ending up in the media timeout handler and tearing down the call. 

