### PR TITLE
kill s2s sessions

### DIFF
--- a/lib/tasks/llm/index.js
+++ b/lib/tasks/llm/index.js
@@ -49,6 +49,22 @@ class TaskLlm extends Task {
       await this.llmMcpService.init();
     }
     await this.llm.exec(cs, {ep});
+
+    /* If the *vendor* ended the s2s session itself (WS disconnect, server error,
+     * etc.) rather than us kill()ing it, the freeswitch media session is still
+     * bound to the caller's endpoint. Its audio then bleeds into whatever verb
+     * runs next — most visibly a `dial` that bridges another leg onto the same
+     * (anchored) endpoint, so the caller/recording hears the agent mixed with the
+     * transferred party (issue: elevenlabs "not hanging up" / mixed audio).
+     * Tear the vendor session down now, before any follow-on verb executes.
+     * Skipped when kill() already deleted it (this.killed) or the call is gone. */
+    if (!this.killed && !cs.callGone && cs?.ep?.uuid) {
+      try {
+        await this.llm.kill(cs);
+      } catch (err) {
+        this.logger.info({err}, 'TaskLlm:exec - error tearing down orphaned s2s media session');
+      }
+    }
   }
 
   async kill(cs) {

--- a/lib/tasks/llm/llms/elevenlabs_s2s.js
+++ b/lib/tasks/llm/llms/elevenlabs_s2s.js
@@ -124,11 +124,8 @@ class TaskLlmElevenlabs_S2S extends Task {
   async kill(cs) {
     super.kill(cs);
 
-    /* cs.ep is null after a bridged Layer-1 handoff (ep released into bridge) — nothing to delete. */
-    if (cs?.ep?.uuid) {
-      this._api(cs.ep, [cs.ep.uuid, SessionDelete])
-        .catch((err) => this.logger.info({err}, 'TaskLlmElevenlabs_S2S:kill - error deleting session'));
-    }
+    this._api(cs.ep, [cs.ep.uuid, SessionDelete])
+      .catch((err) => this.logger.info({err}, 'TaskLlmElevenlabs_S2S:kill - error deleting session'));
 
     this.notifyTaskDone();
   }

--- a/lib/tasks/llm/llms/elevenlabs_s2s.js
+++ b/lib/tasks/llm/llms/elevenlabs_s2s.js
@@ -124,8 +124,11 @@ class TaskLlmElevenlabs_S2S extends Task {
   async kill(cs) {
     super.kill(cs);
 
-    this._api(cs.ep, [cs.ep.uuid, SessionDelete])
-      .catch((err) => this.logger.info({err}, 'TaskLlmElevenlabs_S2S:kill - error deleting session'));
+    /* cs.ep is null after a bridged Layer-1 handoff (ep released into bridge) — nothing to delete. */
+    if (cs?.ep?.uuid) {
+      this._api(cs.ep, [cs.ep.uuid, SessionDelete])
+        .catch((err) => this.logger.info({err}, 'TaskLlmElevenlabs_S2S:kill - error deleting session'));
+    }
 
     this.notifyTaskDone();
   }


### PR DESCRIPTION
backport of https://github.com/jambonz/feature-server/pull/141

Differences from the 10.x fix (intentional)

No conference guard. 0.9.x has no _context/moveToConference concept for S2S sessions, so the this._context !== 'conference' condition is omitted — there's no room-owned engine to protect.

No try/catch around this.llm.exec(). 0.9.x doesn't wrap the vendor exec (10.x does, to swallow a rejected actionHook). I kept the backport minimal and didn't add that — the teardown runs after a normal vendor-initiated end, which is the reported bug and doesn't throw. If you'd prefer parity, I can wrap it, but it's a behavior change beyond this fix.