### PR TITLE
fix(amd): empty final transcript must not produce a human verdict

### DIFF
--- a/lib/utils/amd-utils.js
+++ b/lib/utils/amd-utils.js
@@ -153,7 +153,8 @@ class Amd extends Emitter {
     this.logger.debug({t}, 'Amd:evaluateTranscription - normalized');
 
     if (Array.isArray(t.alternatives) && t.alternatives.length > 0) {
-      const wordCount = t.alternatives[0].transcript.split(' ').length;
+      const transcript = (t.alternatives[0].transcript || '').trim();
+      const wordCount = transcript.length > 0 ? transcript.split(' ').length : 0;
       const final = t.is_final;
 
       const foundHint = hints.find((h) =>  t.alternatives[0].transcript.toLowerCase().includes(h.toLowerCase()));
@@ -174,8 +175,8 @@ class Amd extends Emitter {
           language: t.language_code
         });
       }
-      else if (final && wordCount < this.thresholdWordCount) {
-        /* a short greeting is typically a human */
+      else if (final && wordCount > 0 && wordCount < this.thresholdWordCount) {
+        /* a short greeting is typically a human; an empty final (e.g. from silence) is no evidence either way */
         this.emit(this.decision = AmdEvents.HumanDetected, {
           reason: 'short greeting',
           greeting: t.alternatives[0].transcript,


### PR DESCRIPTION
## What's wrong

In `lib/utils/amd-utils.js`, `Amd.evaluateTranscription` computes the word count as:

```js
const wordCount = t.alternatives[0].transcript.split(' ').length;
```

For an empty final transcript (`''`), `''.split(' ')` returns `['']`, so `wordCount` is `1`. That satisfies the human branch:

```js
else if (final && wordCount < this.thresholdWordCount) {
```

so an empty final — no speech at all — emits `AmdEvents.HumanDetected` with `reason: 'short greeting'` and an empty `greeting`.

## How to reproduce

Run AMD with Deepgram as the recognizer and dial any number that answers with silence or a voicemail with a long opening pause. Deepgram routinely emits empty finals (`speech_final: true` with an empty transcript) on silence. The very first empty final ends the AMD decision as `amd_human_detected` before any audio evidence exists.

## Production impact

We run jambonz self-hosted for a production outbound dialer doing ~10k AMD-screened calls/day. Before we deployed an app-side guard, 35% of our human verdicts (346/993 bridges over 7 days) had an empty greeting, and 84% of those calls were actually voicemail — agents were bridged into silence.

## The fix

Compute the word count on the trimmed transcript, and treat 0 words as no-decision: the empty final no longer matches the human branch, and AMD keeps listening (the decision/no-speech timers still govern the overall outcome). Three lines changed, no restructuring.

Verified present on both v0.9.7 and current main (`lib/utils/amd-utils.js` is byte-identical between them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
