### PR TITLE
fix(amd): plumb shortUtterance (and punctuation) recognizer options through to normalizeTranscription

### DIFF
--- a/lib/utils/amd-utils.js
+++ b/lib/utils/amd-utils.js
@@ -71,6 +71,8 @@ class Amd extends Emitter {
     this.setChannelVarsForStt = setChannelVarsForStt;
     this.digitCount = opts.digitCount || 0;
     this.numberRegEx = RegExp(`[0-9]{${this.digitCount}}`);
+    this.shortUtterance = opts.recognizer?.deepgramOptions?.shortUtterance;
+    this.punctuation = opts.recognizer?.punctuation;
 
     const {
       noSpeechTimeoutMs = 5000,
@@ -147,7 +149,7 @@ class Amd extends Emitter {
     this.stopNoSpeechTimer();
 
     this.logger.debug({evt}, 'Amd:evaluateTranscription - raw');
-    const t = this.normalizeTranscription(evt, this.vendor, this.language);
+    const t = this.normalizeTranscription(evt, this.vendor, 1, this.language, this.shortUtterance, this.punctuation);
     const hints = voicemailHints[this.language] || [];
 
     this.logger.debug({t}, 'Amd:evaluateTranscription - normalized');


### PR DESCRIPTION
## What's wrong

`lib/utils/amd-utils.js` (line 150) calls:

```js
const t = this.normalizeTranscription(evt, this.vendor, this.language);
```

but the signature in `lib/utils/transcription-utils.js` (line 770) is:

```js
const normalizeTranscription = (evt, vendor, channel, language, shortUtterance, punctuation) => {
```

So `language` lands in the `channel` slot, `language` is `undefined`, and `shortUtterance`/`punctuation` are always `undefined`.

## Consequence

- `deepgramOptions.shortUtterance` (already supported by `normalizeDeepgram`: `is_final: shortUtterance ? evt.is_final : evt.speech_final`) can never affect AMD. The human branch therefore always waits for a full `speech_final` (the endpointing silence window) even when an operator has opted into faster `is_final` semantics — on a high-volume dialer that's several hundred ms of avoidable dead air on every human connect.
- The normalized event's `channel_tag` gets the language string and `language_code` is `undefined`.

## The fix

Pass the correct positional args, matching how `gather` calls it (`lib/tasks/gather.js` line 946: `this.normalizeTranscription(evt, this.vendor, 1, this.language, this.shortUtterance, this.data.recognizer.punctuation)`): channel `1`, then `shortUtterance` and `punctuation` sourced from the task's recognizer options the same way gather does (`recognizer?.deepgramOptions?.shortUtterance` / `recognizer?.punctuation`).

Verified present on both v0.9.7 and current main (`lib/utils/amd-utils.js` is byte-identical between them). We run jambonz self-hosted for a production outbound dialer doing ~10k AMD-screened calls/day, where AMD verdict latency directly determines agent dead air.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
