### PR TITLE
fix: send mid-call DTMF via media-server send_dtmf

### DIFF
--- a/lib/http-routes/api/update-call.js
+++ b/lib/http-routes/api/update-call.js
@@ -60,6 +60,12 @@ router.post('/:callSid', async(req, res) => {
         reason: response.reason
       });
     }
+    else if (req.body.dtmf) {
+      /* Await DTMF and surface hard failures — rtpengine play DTMF via SIP INFO
+       * can ACK without emitting RFC2833; media-server send_dtmf is the reliable path. */
+      const response = await cs.updateCall(req.body, callSid);
+      res.status(200).json(response || {ok: true});
+    }
     else {
       res.sendStatus(202);
       cs.updateCall(req.body, callSid);

--- a/lib/session/call-session.js
+++ b/lib/session/call-session.js
@@ -1767,7 +1767,24 @@ class CallSession extends Emitter {
   }
 
   /**
-   * perform live call control - send RFC 2833 DTMF
+   * Resolve the media-server endpoint to inject mid-call DTMF onto.
+   * During Dial: epOther = A-leg (parent), ep = B-leg (child). Same mapping as Dial.whisper.
+   * Mid-call DTMF should go through media-server send_dtmf — rtpengine play DTMF
+   * via SIP INFO is unreliable (ACK with no RFC2833 telephone-event on some calls).
+   */
+  _getEndpointForDtmf(callSid) {
+    const task = this.currentTask;
+    if (task?.name === TaskName.Dial) {
+      /* dial.callSid is the child/B-leg; parent uses epOther (A-leg-facing) */
+      if (callSid && callSid === task.callSid) return task.ep;
+      return task.epOther || this.ep;
+    }
+    return this.ep;
+  }
+
+  /**
+   * perform live call control - send RFC 2833 DTMF via media server (same path as dtmf verb).
+   * Throws on failure so the caller/API can treat DTMF as a hard dependency.
    * @param {obj} opts
    * @param {string} opts.dtmf.digit - DTMF digit
    * @param {string} opts.dtmf.duration - Optional, Duration
@@ -1776,25 +1793,50 @@ class CallSession extends Emitter {
     const {dtmf} = opts;
     const {digit, duration = 250} = dtmf;
     if (!this.hasStableDialog) {
-      this.logger.info('CallSession:_lccDtmf - invalid command as we do not have a stable call');
-      return;
+      const err = new Error('CallSession:_lccDtmf - invalid command as we do not have a stable call');
+      this.logger.error(err.message);
+      throw err;
     }
+    let span;
     try {
-      const dlg = callSid === this.callSid ? this.dlg : this.currentTask.dlg;
-      const res = await dlg.request({
-        method: 'INFO',
-        headers: {
-          'Content-Type': 'application/dtmf',
-          'X-Reason': 'Dtmf'
-        },
-        body: `Signal=${digit}
-Duration=${duration} `
+      ({span} = this.rootSpan.startChildSpan(`dtmf:${digit}`));
+      span.setAttributes({
+        channel: 1,
+        dtmf: digit,
+        duration: `${duration}ms`,
+        'dtmf.source': 'updateCall'
       });
-      this.logger.debug({res}, `CallSession:_lccDtmf
- got response to INFO DTMF digit=${digit} and duration=${duration}`);
-      return res;
+
+      const dialTask = this.currentTask?.name === TaskName.Dial ? this.currentTask : null;
+      let ep = this._getEndpointForDtmf(callSid);
+
+      /* If media was released, re-anchor like whisper so we can use send_dtmf */
+      if ((!ep || !ep.connected) && dialTask?.sd) {
+        this.logger.info({callSid, digit},
+          'CallSession:_lccDtmf media endpoint missing; re-anchoring before send_dtmf');
+        await dialTask.reAnchorMedia(this, dialTask.sd);
+        ep = this._getEndpointForDtmf(callSid);
+      }
+
+      if (!ep?.connected) {
+        const err = new Error(
+          'CallSession:_lccDtmf - no connected media endpoint for send_dtmf (refusing SIP INFO fallback)');
+        this.logger.error({callSid, digit, duration}, err.message);
+        span.setAttributes({'dtmf.method': 'failed', 'dtmf.error': 'no-endpoint'});
+        throw err;
+      }
+
+      this.logger.info({digit, duration, uuid: ep.uuid},
+        'CallSession:_lccDtmf sending via media endpoint send_dtmf');
+      span.setAttributes({'dtmf.method': 'send_dtmf'});
+      await ep.execute('send_dtmf', `${digit}@${duration}`);
+      return {ok: true, method: 'send_dtmf', digit, duration};
     } catch (err) {
-      this.logger.error({err}, 'CallSession:_lccDtmf - error sending INFO RFC 2833 DTMF');
+      this.logger.error({err, digit, duration, callSid}, 'CallSession:_lccDtmf - error sending DTMF');
+      if (span) span.setAttributes({'dtmf.error': err.message});
+      throw err;
+    } finally {
+      if (span) span.end();
     }
   }
 
@@ -2026,7 +2068,7 @@ Duration=${duration} `
         const res = await this._lccSipRequest(opts, callSid);
         return {status: res.status, reason: res.reason};
       } else if (opts.dtmf) {
-        await this._lccDtmf(opts, callSid);
+        return await this._lccDtmf(opts, callSid);
       }
       else if (opts.record) {
         await this.notifyRecordOptions(opts.record);
@@ -2072,6 +2114,8 @@ Duration=${duration} `
       } catch (err) {
         this.logger.error({err}, 'Error writing error-updating-call alert');
       }
+      /* Re-throw DTMF failures so HTTP updateCall can return 500 to the client */
+      if (opts.dtmf) throw err;
     }
   }
 


### PR DESCRIPTION
## Summary
- Mid-call `updateCall` DTMF previously used SIP INFO → SBC → rtpengine `play DTMF`, which can ACK while emitting no RFC2833 telephone-event packets on some calls.
- Prefer media-server `send_dtmf` (same path as the `dtmf` verb), re-anchor dial media when the endpoint is missing, and refuse the unreliable SIP INFO fallback.
- Await DTMF `updateCall` requests and return 200/500 so callers can treat failures as hard errors.

## Motivation
Observed on a production-like standalone install (and consistent with cloud reports): early `dtmf` verb tones always appear on the wire as RFC2833, while mid-call `updateCall` DTMF intermittently produced silence after rtpengine accepted `play DTMF`. Generating the tone in the media server matches the reliable verb path.

## Test plan
- [ ] Place inbound call with app response `[pause, dtmf:1, dial{anchorMedia:true}]`
- [ ] After answer, PATCH `updateCall` with `{dtmf:{digit:"0",duration:500}}`
- [ ] Confirm feature-server logs `sending via media endpoint send_dtmf` (no rtpengine `play DTMF`)
- [ ] Confirm tcpdump/Wireshark `rtpevent` shows both DTMF One and DTMF Zero toward the caller media IP
- [ ] Confirm DTMF updateCall returns 200 JSON on success
- [ ] Force missing endpoint (media released) and confirm re-anchor attempt / 500 if send still impossible


Made with [Cursor](https://cursor.com)