### PR TITLE
fix: return tts:tokens-result when tts:tokens command is missing id (#1548)

### DIFF
--- a/lib/session/call-session.js
+++ b/lib/session/call-session.js
@@ -1986,7 +1986,10 @@ Duration=${duration} `
 
     if (id === undefined) {
       this.logger.info({opts}, 'CallSession:_lccTtsTokens - invalid command since id is missing');
-      return;
+      return this.requestor.request('tts:tokens-result', '/tokens-result', {
+        status: 'failed',
+        reason: 'missing id'
+      }).catch((err) => this.logger.debug({err}, 'CallSession:_notifyTaskStatus - Error sending'));
     }
     else if (tokens === undefined) {
       this.logger.info({opts}, 'CallSession:_lccTtsTokens - invalid command since tokens is missing');

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ require('./ws-requestor-unit-test');
 require('./http-requestor-retry-test');
 require('./http-requestor-unit-test');
 require('./unit-tests');
+require('./tts-tokens-missing-id-test');
 require('./hold-unhold-test');
 require('./docker_start');
 require('./create-test-db');

--- a/test/tts-tokens-missing-id-test.js
+++ b/test/tts-tokens-missing-id-test.js
@@ -1,0 +1,34 @@
+const test = require('tape');
+const sinon = require('sinon');
+const CallSession = require('../lib/session/call-session');
+
+// Regression test for #1548: _lccTtsTokens must not silently drop a tts:tokens
+// command that is missing `id`. It should reply with a tts:tokens-result of
+// status 'failed'/reason 'missing id', mirroring how a missing `tokens` field
+// is already handled — otherwise the WS client (e.g. the Python SDK, which does
+// not send `id`) gets no feedback at all.
+
+const buildFakeSession = () => {
+  const requestor = { request: sinon.stub().resolves({}) };
+  const logger = { info: sinon.stub(), debug: sinon.stub() };
+  return { requestor, logger, ttsStreamingBuffer: { bufferTokens: sinon.stub().resolves({}) } };
+};
+
+test('_lccTtsTokens: missing id returns a failed tts:tokens-result instead of silently dropping', async (t) => {
+  const session = buildFakeSession();
+
+  // WHEN a tts:tokens command arrives without `id`
+  await CallSession.prototype._lccTtsTokens.call(session, {tokens: 'hello world'});
+
+  // THEN a tts:tokens-result with status 'failed'/reason 'missing id' is sent back
+  t.ok(session.requestor.request.calledOnce, 'requestor.request should be called once');
+  const [type, path, payload] = session.requestor.request.firstCall.args;
+  t.equal(type, 'tts:tokens-result', 'response type is tts:tokens-result');
+  t.equal(path, '/tokens-result', 'response path is /tokens-result');
+  t.equal(payload.status, 'failed', 'status is failed');
+  t.equal(payload.reason, 'missing id', 'reason is missing id');
+
+  // AND tokens are never buffered for an invalid command
+  t.ok(session.ttsStreamingBuffer.bufferTokens.notCalled, 'tokens are not buffered when id is missing');
+  t.end();
+});


### PR DESCRIPTION
## Summary

Fix #1548

`CallSession._lccTtsTokens` silently `return`ed when a `tts:tokens` command
arrived without an `id`, so the WebSocket client got no `tts:tokens-result`,
no audio, and no error — only a server-side `info` log. This is especially
painful because the Python SDK's `send_tts_tokens()` does not send `id`, so
every such call was dropped with no feedback.

The missing-`id` branch now replies with a `tts:tokens-result` of
`status: 'failed'` / `reason: 'missing id'`, mirroring the existing
missing-`tokens` branch a few lines below.

## Test verification (RED → GREEN)

New focused test `test/tts-tokens-missing-id-test.js` drives `_lccTtsTokens`
with a stubbed session (no docker/cloud needed) and asserts a
`tts:tokens-result` is sent.

RED — on unmodified `main` (silent `return`, no response sent):

```
not ok 1 requestor.request should be called once
1..2
# tests 2
# pass  0
# fail  2
```

GREEN — with the fix applied:

```
ok 2 response type is tts:tokens-result
ok 3 response path is /tokens-result
ok 4 status is failed
ok 5 reason is missing id
ok 6 tokens are not buffered when id is missing
1..6
# tests 6
# pass  6
```

## Full local suite

Full local validation suite (`npm run jslint` + the pre-docker unit suite from
`.github/workflows/build.yml`) is green with no regressions vs. the `main`
baseline; the docker/cloud integration matrix is left to CI:

```
ws-requestor-retry-unit-test: pass=20 fail=0
test_ws_retry_comprehensive: pass=7 fail=0
ws-requestor-unit-test: pass=5 fail=0
http-requestor-retry-test: pass=6 fail=0
http-requestor-unit-test: pass=22 fail=0
unit-tests: pass=19 fail=0
tts-tokens-missing-id-test: pass=6 fail=0
TOTAL_FAIL=0
CI PASS
```

## Files changed

| File | Change |
|------|--------|
| `lib/session/call-session.js` | missing-`id` branch now returns a `tts:tokens-result` failure instead of silently dropping |
| `test/tts-tokens-missing-id-test.js` | new regression test for the missing-`id` path |
| `test/index.js` | register the new test in the pre-docker unit suite |
