### PR TITLE
fix: include tag/customerData in LLM tool hook (#1284)

### DIFF
--- a/lib/tasks/llm/index.js
+++ b/lib/tasks/llm/index.js
@@ -127,7 +127,11 @@ class TaskLlm extends Task {
 
 
   async sendToolHook(tool_call_id, data) {
-    const tool_response = await this.cs?.requestor.request('llm:tool-call', this.toolHook, {tool_call_id, ...data});
+    // #1284: include the tag/customerData (set via the tag verb) in the tool hook,
+    // mirroring how every verb/action hook carries it via callInfo.toJSON().
+    const customerData = this.cs?.callInfo?.customerData;
+    const tool_response = await this.cs?.requestor.request('llm:tool-call', this.toolHook,
+      {tool_call_id, ...(customerData && {customerData}), ...data});
     // if the toolHook was a websocket it will return undefined, otherwise it should return an object
     if (typeof tool_response != 'undefined') {
       // If the webhook didn't declare a `type`, assume the legacy Ultravox-style

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ require('./ws-requestor-unit-test');
 require('./http-requestor-retry-test');
 require('./http-requestor-unit-test');
 require('./unit-tests');
+require('./llm-toolhook-tag-test');
 require('./hold-unhold-test');
 require('./docker_start');
 require('./create-test-db');

--- a/test/llm-toolhook-tag-test.js
+++ b/test/llm-toolhook-tag-test.js
@@ -1,0 +1,44 @@
+const test = require('tape');
+const sinon = require('sinon');
+const TaskLlm = require('../lib/tasks/llm');
+
+// Regression test for #1284: the LLM tool hook (llm:tool-call) must carry the
+// tag/customerData that was set via the `tag` verb, the same way every other
+// verb/action hook does via callInfo.toJSON(). Before the fix the payload was
+// just {tool_call_id, ...data}, so applications never saw their tag data on a
+// tool call (over webhook or websocket).
+
+const buildFakeTask = (customerData) => {
+  const requestor = { request: sinon.stub().resolves(undefined) };
+  // Object.create so the real `toolHook` getter (reads this.llm?.toolHook) resolves.
+  const task = Object.create(TaskLlm.prototype);
+  task.cs = { requestor, callInfo: { customerData } };
+  task.llm = { toolHook: { url: '/tool' } };
+  return task;
+};
+
+test('sendToolHook: includes customerData (tag) in the tool-call payload', async (t) => {
+  const task = buildFakeTask({ accountId: 'abc', foo: 'bar' });
+
+  await TaskLlm.prototype.sendToolHook.call(task, 'tc-1', { name: 'lookup', args: { q: 1 } });
+
+  t.ok(task.cs.requestor.request.calledOnce, 'requestor.request called once');
+  const [type, hook, payload] = task.cs.requestor.request.firstCall.args;
+  t.equal(type, 'llm:tool-call', 'hook type is llm:tool-call');
+  t.equal(hook, task.llm.toolHook, 'hook target is the toolHook');
+  t.deepEqual(payload.customerData, { accountId: 'abc', foo: 'bar' }, 'customerData is included');
+  t.equal(payload.tool_call_id, 'tc-1', 'tool_call_id is preserved');
+  t.equal(payload.name, 'lookup', 'tool data (name) is preserved');
+  t.end();
+});
+
+test('sendToolHook: omits customerData when no tag was set', async (t) => {
+  const task = buildFakeTask(undefined);
+
+  await TaskLlm.prototype.sendToolHook.call(task, 'tc-2', { name: 'lookup', args: {} });
+
+  const [, , payload] = task.cs.requestor.request.firstCall.args;
+  t.notOk('customerData' in payload, 'customerData key is absent when unset');
+  t.equal(payload.tool_call_id, 'tc-2', 'tool_call_id is preserved');
+  t.end();
+});


### PR DESCRIPTION
## Summary

Fix #1284

The `llm:tool-call` hook (`sendToolHook`) sent only `{tool_call_id, ...data}`,
so tag data set with the `tag` verb before an LLM verb never reached the
application when a tool was invoked — over webhook or websocket.

Every other verb/action hook already carries this data: `performAction`
(`lib/tasks/task.js`) merges `cs.callInfo.toJSON()`, which includes
`customerData`. This change attaches the same `customerData` to the tool-call
payload. `lib/utils/http-requestor.js` already keeps `customerData`
un-snake-cased, confirming it is the canonical top-level payload key.

## Change

- `lib/tasks/llm/index.js` — `sendToolHook` now includes
  `this.cs.callInfo.customerData` (omitted when no tag was set).

## Test verification (RED → GREEN)

New unit test `test/llm-toolhook-tag-test.js` (runs pre-docker in `test/index.js`).

RED (fix reverted, on `main`):
```
not ok 4 customerData is included
# tests 8
# pass  7
# fail  1
```

GREEN (with fix):
```
ok 4 customerData is included
# tests 8
# pass  8
# ok
```

## Full local suite

jslint + the standalone pre-docker unit tests. Baseline `main`: 79 pass / 0 fail.
This branch: 87 pass / 0 fail (adds the 8 new assertions, no regressions). The
full integration matrix requires the docker testbed + cloud secrets and runs in CI.
