### PR TITLE
fix(tts): send stream_resumed to the same hook path as the other stream events

### DIFF
--- a/lib/session/call-session.js
+++ b/lib/session/call-session.js
@@ -3285,7 +3285,7 @@ Duration=${duration} `
   }
 
   _onTtsStreamingResume() {
-    this.requestor?.request('tts:streaming-event', 'streaming-event', {event_type: 'stream_resumed'})
+    this.requestor?.request('tts:streaming-event', '/streaming-event', {event_type: 'stream_resumed'})
       .catch((err) => this.logger.info({err}, 'CallSession:_onTtsStreamingResume - Error sending'));
   }
 

--- a/test/unit/tts-streaming-events.test.js
+++ b/test/unit/tts-streaming-events.test.js
@@ -1,0 +1,64 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+/* call-session decrypts credentials at require time, so it needs a secret present */
+process.env.ENCRYPTION_SECRET = process.env.ENCRYPTION_SECRET || 'foobar';
+process.env.JAMBONES_LOGLEVEL = process.env.JAMBONES_LOGLEVEL || 'error';
+
+const CallSession = require('../../lib/session/call-session');
+
+/* Only the requestor and logger are touched by these handlers, so the rest of a
+   CallSession is deliberately left unbuilt. */
+const makeSession = () => {
+  const sent = [];
+  const session = Object.create(CallSession.prototype);
+
+  Object.assign(session, {
+    application: {
+      requestor: {
+        request: async (type, hook, payload) => {
+          sent.push({type, hook, payload});
+        }
+      }
+    },
+    logger: {info: () => {}, debug: () => {}, error: () => {}}
+  });
+
+  return {session, sent};
+};
+
+test('the stream_resumed event is sent to the same hook path as every other one', async () => {
+  /* A hook path only gets joined to the application's baseUrl when it starts with
+     a slash (HttpRequestor: `_isRelativeUrl(url) ? baseUrl + url : url`). Sending
+     "streaming-event" instead of "/streaming-event" is neither relative nor
+     absolute, so it never reaches an HTTP application at all — and the failure is
+     swallowed by the .catch on the call site, so nothing surfaces. */
+  const {session, sent} = makeSession();
+
+  session._onTtsStreamingResume();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.strictEqual(sent.length, 1);
+  assert.strictEqual(sent[0].hook, '/streaming-event',
+    'stream_resumed must use an absolute-from-base hook path');
+  assert.strictEqual(sent[0].payload.event_type, 'stream_resumed');
+});
+
+test('pause and resume agree on the hook path', async () => {
+  /* These two are a pair; if they ever diverge again, an application would get
+     one half of the pause/resume cycle and silently lose the other. */
+  const {session, sent} = makeSession();
+
+  session._onTtsStreamingPause();
+  session._onTtsStreamingResume();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepStrictEqual(
+    sent.map(({hook}) => hook),
+    ['/streaming-event', '/streaming-event']
+  );
+  assert.deepStrictEqual(
+    sent.map(({payload}) => payload.event_type),
+    ['stream_paused', 'stream_resumed']
+  );
+});


### PR DESCRIPTION
Found by reading the file rather than from a bug report, so there is no issue to close.

## The problem

`_onTtsStreamingResume` asks for the hook path `"streaming-event"`. Every other TTS streaming event — `stream_open`, `stream_paused`, `stream_closed`, `user_interruption` — asks for `"/streaming-event"`.

That one missing slash decides whether the event reaches an HTTP application at all. `HttpRequestor` joins a hook path onto the application's `baseUrl` only when the path is *relative*, and relative means starting with a slash:

```js
_isRelativeUrl(u) { return typeof u === 'string' && u.startsWith('/'); }
...
const absUrl = this._isRelativeUrl(url) ? `${this.baseUrl}${url}` : url;
```

`"streaming-event"` is neither relative by that test nor absolute, so it falls through the ternary unjoined and is used as-is. It never lands on the application.

What makes it easy to miss is that the call site catches and logs rather than raising:

```js
.catch((err) => this.logger.info({err}, 'CallSession:_onTtsStreamingResume - Error sending'));
```

So from the application's side there is simply a `stream_paused` with no matching `stream_resumed`, and nothing anywhere says why. Any app tracking pause/resume as a pair — to drive a UI state, or to know when it can resume feeding tokens — sees the stream go quiet and stay that way.

Present since the verb was introduced in #994.

## The fix

One character. All six call sites now use `/streaming-event`:

```
$ grep -o "'/*streaming-event'" lib/session/call-session.js lib/tasks/say.js | sort | uniq -c
      6 '/streaming-event'
```

## Tests

Two cases in a new `test/unit/tts-streaming-events.test.js`. Both fail against the unpatched line and pass with it:

```
✖ the stream_resumed event is sent to the same hook path as every other one
✖ pause and resume agree on the hook path
tests 2 | pass 0 | fail 2      <- without the fix
tests 10 | pass 10 | fail 0    <- with it, whole unit suite
```

The second is deliberately a pair-check rather than another assertion on the same constant, so that if the two ever diverge again the test says which half an application would lose. `npm run jslint` is clean.

## Noticed while in here, not fixed

`lib/tasks/say.js:202` carries `//TODO: send tts:streaming-event with error?` — on a streaming failure the application currently gets a plain `stream_closed`, indistinguishable from a normal close, with the reason only in the server log. That needs a new `event_type` on a public hook, so it seemed like your call rather than something to slip into this PR. Happy to open it separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
